### PR TITLE
82 catch grpc error to inform the user

### DIFF
--- a/src/reachy_v2_sdk/reachy_sdk.py
+++ b/src/reachy_v2_sdk/reachy_sdk.py
@@ -106,6 +106,14 @@ is running and that the IP is correct."
         return self._disabled_parts
 
     @property
+    def grpc_status(self) -> str:
+        """Get the status of the connection with the robot.
+
+        Can be either 'connected' or 'disconnected'.
+        """
+        return self._grpc_status
+
+    @property
     def _grpc_status(self) -> str:
         if self._grpc_connected:
             return "connected"
@@ -121,7 +129,7 @@ is running and that the IP is correct."
             self._grpc_channel.close()
             attributs = [attr for attr in dir(self) if not attr.startswith("_")]
             for attr in attributs:
-                if attr not in ["turn_on", "turn_off", "enabled_parts", "disabled_parts"]:
+                if attr not in ["grpc_status", "turn_on", "turn_off", "enabled_parts", "disabled_parts"]:
                     delattr(self, attr)
         else:
             raise ValueError("_grpc_status can only be set to 'connected' or 'disconnected'")


### PR DESCRIPTION
Handles two situations:
1. **At init**: catch _InactiveRpcError when the IP address provided by the user is incorrect or the sdk server is not running.
2. **During use**: catch the rpc error crashing the update state and commands threads.

Introduction of an attribute *grpc_status* where if set to *"disconnected"* deletes the attributes of ReachySDK so that the user can't have access to the parts of the robot. Only 2 methods (*turn_on()* and *turn_off()*) and 2 attributes (*disabled_parts* and *enabled_parts*) remain but if the user tries to use it on a disconnected robot, they indicate it and do noting if called. 

This is just a proposition, we can totally do something else instead. 