### PR TITLE
Move orient and rotate_to to orbita3d

### DIFF
--- a/src/reachy_v2_sdk/head.py
+++ b/src/reachy_v2_sdk/head.py
@@ -14,7 +14,7 @@ from typing import Optional, Tuple, Dict
 
 from reachy_sdk_api_v2.head_pb2_grpc import HeadServiceStub
 from reachy_sdk_api_v2.head_pb2 import Head as Head_proto, HeadState
-from reachy_sdk_api_v2.head_pb2 import HeadLookAtGoal, NeckGoal
+from reachy_sdk_api_v2.head_pb2 import HeadLookAtGoal
 from reachy_sdk_api_v2.head_pb2 import HeadPosition, NeckOrientation
 from reachy_sdk_api_v2.head_pb2 import NeckFKRequest, NeckIKRequest
 from reachy_sdk_api_v2.part_pb2 import PartId
@@ -122,20 +122,6 @@ class Head:
     def look_at(self, x: float, y: float, z: float, duration: float) -> None:
         req = HeadLookAtGoal(id=self.part_id, point=Point(x=x, y=y, z=z), duration=FloatValue(value=duration))
         self._head_stub.LookAt(req)
-
-    def orient(self, q: pyQuat, duration: float) -> None:
-        req = NeckGoal(
-            id=self.part_id, rotation=Rotation3D(q=Quaternion(w=q.w, x=q.x, y=q.y, z=q.z)), duration=FloatValue(value=duration)
-        )
-        self._head_stub.GoToOrientation(req)
-
-    def rotate_to(self, roll: float, pitch: float, yaw: float, duration: float) -> None:
-        req = NeckGoal(
-            id=self.part_id,
-            rotation=Rotation3D(rpy=ExtEulerAngles(roll=roll, pitch=pitch, yaw=yaw)),
-            duration=FloatValue(value=duration),
-        )
-        self._head_stub.GoToOrientation(req)
 
     def turn_on(self) -> None:
         self._head_stub.TurnOn(self.part_id)


### PR DESCRIPTION
I suggest to move functions *orient* and *rotate_to* at Orbita3D level. Calls should then look like:
- `reachy.r_arm.wrist.orient(....)`
- `reachy.head.neck.orient(....)`