### PR TITLE
Set stream freq to 80Hz

### DIFF
--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -455,8 +455,8 @@ is running and that the IP is correct."
 
         try:
             await asyncio.gather(
-                self._stream_orbita2d_commands_loop(orbita2d_stub, freq=100),
-                self._stream_orbita3d_commands_loop(orbita3d_stub, freq=100),
+                self._stream_orbita2d_commands_loop(orbita2d_stub, freq=80),
+                self._stream_orbita3d_commands_loop(orbita3d_stub, freq=80),
                 # self._stream_dynamixel_motor_commands_loop(dynamixel_motor_stub, freq=100),
                 self._get_stream_update_loop(reachy_stub, freq=100),
                 self._wait_for_stop(),


### PR DESCRIPTION
Setting stream freq to 80Hz seems to give enough time for the server to internally update its state and avoid overwriting of the goal_position