### PR TITLE
Remove definitively MobileBaseSDK

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ install_requires =
     grpcio>=1.59.0, <=1.62.2
     pyquaternion==0.9.9
     opencv-python>=4.8.0, <4.9.0
-    mobile-base-sdk>=1.0.2, <1.1.0
     reachy2-sdk-api>=1.0.6,  <1.1.0
 
 [options.packages.find]
@@ -35,6 +34,7 @@ dev = black==23.12.1
       isort==5.13.2
       types-protobuf>=4.24.0,<=4.25.3
       pdoc>=14.0.0,<=14.4.0
+examples = pillow==10.4.0
 
 [flake8]
 exclude = *test*

--- a/src/reachy2_sdk/config/reachy_info.py
+++ b/src/reachy2_sdk/config/reachy_info.py
@@ -4,8 +4,9 @@ This module provides main info of the robot.
 """
 from typing import Any, Dict, List, Optional
 
-from mobile_base_sdk import MobileBaseSDK
 from reachy2_sdk_api.reachy_pb2 import Reachy
+
+from ..parts.mobile_base import MobileBase
 
 
 class ReachyInfo:
@@ -25,7 +26,7 @@ class ReachyInfo:
 
         self._enabled_parts: Dict[str, Any] = {}
         self._disabled_parts: List[str] = []
-        self._mobile_base: Optional[MobileBaseSDK] = None
+        self._mobile_base: Optional[MobileBase] = None
 
         self._set_config(reachy)
 
@@ -46,7 +47,7 @@ class ReachyInfo:
         else:
             self.config = "custom_config"
 
-    def _set_mobile_base(self, mobile_base: MobileBaseSDK) -> None:
+    def _set_mobile_base(self, mobile_base: MobileBase) -> None:
         self._mobile_base = mobile_base
 
     def __repr__(self) -> str:

--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -41,7 +41,7 @@ from .part import Part
 
 
 class MobileBase(Part):
-    """The MobileBaseSDK class handles the connection with Reachy's mobile base.
+    """The MobileBase class handles Reachy's mobile base.
 
     It holds:
 


### PR DESCRIPTION
We do not use Mobile base SDK anymore, but it was still imported in ReachyInfo