### PR TITLE
322 lidar safety cannot be set

### DIFF
--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -18,12 +18,12 @@ from google.protobuf.empty_pb2 import Empty
 from google.protobuf.wrappers_pb2 import BoolValue, FloatValue
 from numpy import deg2rad, rad2deg, round
 from reachy2_sdk_api.mobile_base_lidar_pb2 import LidarSafety
+from reachy2_sdk_api.mobile_base_lidar_pb2_grpc import MobileBaseLidarServiceStub
 from reachy2_sdk_api.mobile_base_mobility_pb2 import (
     DirectionVector,
     GoToVector,
     TargetDirectionCommand,
 )
-from reachy2_sdk_api.mobile_base_lidar_pb2_grpc import MobileBaseLidarServiceStub
 from reachy2_sdk_api.mobile_base_mobility_pb2_grpc import MobileBaseMobilityServiceStub
 from reachy2_sdk_api.mobile_base_utility_pb2 import (
     ControlModeCommand,

--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -15,10 +15,8 @@ from typing import Dict, Optional
 
 import grpc
 from google.protobuf.empty_pb2 import Empty
-from google.protobuf.wrappers_pb2 import BoolValue, FloatValue
+from google.protobuf.wrappers_pb2 import FloatValue
 from numpy import deg2rad, rad2deg, round
-from reachy2_sdk_api.mobile_base_lidar_pb2 import LidarSafety
-from reachy2_sdk_api.mobile_base_lidar_pb2_grpc import MobileBaseLidarServiceStub
 from reachy2_sdk_api.mobile_base_mobility_pb2 import (
     DirectionVector,
     GoToVector,
@@ -65,7 +63,6 @@ class MobileBase(Part):
         super().__init__(mb_msg, grpc_channel, MobileBaseUtilityServiceStub(grpc_channel))
 
         self._mobility_stub = MobileBaseMobilityServiceStub(grpc_channel)
-        self._lidar_stub = MobileBaseLidarServiceStub(grpc_channel)
 
         self._drive_mode: str = ZuuuModePossiblities.keys()[initial_state.zuuu_mode.mode].lower()
         self._control_mode: str = ControlModePossiblities.keys()[initial_state.control_mode.mode].lower()
@@ -273,22 +270,6 @@ class MobileBase(Part):
         if self._drive_mode == "free_wheel":
             return True
         return False
-
-    def _set_safety(self, safety_on: bool, safety_distance: float = 0.0, critical_distance: float = 0.0) -> None:
-        if safety_distance < 0 or critical_distance < 0:
-            raise ValueError("Distances should be positive.")
-
-        if safety_distance == 0.0:
-            safety_distance = self.lidar._safety_distance
-        if critical_distance == 0.0:
-            critical_distance = self.lidar._critical_distance
-
-        req = LidarSafety(
-            safety_on=BoolValue(value=safety_on),
-            safety_distance=FloatValue(value=safety_distance),
-            critical_distance=FloatValue(value=critical_distance),
-        )
-        self._lidar_stub.SetZuuuSafety(req)
 
     def _update_with(self, new_state: MobileBaseState) -> None:
         self._battery_level = new_state.battery_level.level.value

--- a/src/reachy2_sdk/sensors/lidar.py
+++ b/src/reachy2_sdk/sensors/lidar.py
@@ -65,8 +65,6 @@ class Lidar:
         self._stub.SetZuuuSafety(
             LidarSafety(
                 safety_distance=FloatValue(value=value),
-                critical_distance=FloatValue(value=self._critical_distance),
-                safety_on=BoolValue(value=self._safety_enabled),
             )
         )
 
@@ -85,9 +83,7 @@ class Lidar:
     def safety_critical_distance(self, value: float) -> None:
         self._stub.SetZuuuSafety(
             LidarSafety(
-                safety_distance=FloatValue(value=self._safety_distance),
                 critical_distance=FloatValue(value=value),
-                safety_on=BoolValue(value=self._safety_enabled),
             )
         )
 
@@ -100,8 +96,6 @@ class Lidar:
     def safety_enabled(self, value: bool) -> None:
         self._stub.SetZuuuSafety(
             LidarSafety(
-                safety_distance=FloatValue(value=self._safety_distance),
-                critical_distance=FloatValue(value=self._critical_distance),
                 safety_on=BoolValue(value=value),
             )
         )


### PR DESCRIPTION
The lidar safety could not be set because the grpc stub MobileBaseUtilityServiceStub was used to call the grpc method SetZuuuSafety instead of MobileBaseLidarServiceStub.

I added safety_distance and critical_distance as optional arguments as sending a LidarSafety message without them would set their value to 0.0 which is then interpreted as request to 0.0 in the zuuu hal. I you prefer @glannuzel not to let the user the ability to change these values from the sdk level we can also always send the safety and critical distances attributes of the Lidar object.