### PR TITLE
325 unit test assert camera name=teleop stereo=true is none

### DIFF
--- a/tests/units/online/test_camera.py
+++ b/tests/units/online/test_camera.py
@@ -51,15 +51,15 @@ def test_sr_camera(reachy_sdk: ReachySDK) -> None:
 
 @pytest.mark.teleop_camera
 def test_teleop_camera(reachy_sdk: ReachySDK) -> None:
-    assert reachy_sdk._cameras.teleop is not None
+    assert reachy_sdk.cameras.teleop is not None
 
-    frame, ts = reachy_sdk._cameras.teleop.get_frame(CameraView.LEFT)
+    frame, ts = reachy_sdk.cameras.teleop.get_frame(CameraView.LEFT)
     assert frame is not None
     assert frame.dtype == np.uint8
     assert type(ts) == int
     assert ts > 0
 
-    frame_right, ts_right = reachy_sdk._cameras.teleop.get_frame(CameraView.RIGHT)
+    frame_right, ts_right = reachy_sdk.cameras.teleop.get_frame(CameraView.RIGHT)
     assert frame_right is not None
     assert frame_right.dtype == np.uint8
     assert type(ts_right) == int
@@ -67,3 +67,23 @@ def test_teleop_camera(reachy_sdk: ReachySDK) -> None:
 
     # check that we don't return the same frame
     assert not np.array_equal(frame, frame_right)
+
+    height, width, distortion_model, D, K, R, P = reachy_sdk.cameras.teleop.get_parameters(CameraView.LEFT)
+
+    assert height == 720
+    assert width == 960
+    assert distortion_model == "equidistant"
+    assert len(D) == 4
+    assert len(K) == 9
+    assert len(R) == 9
+    assert len(P) == 12
+
+    height, width, distortion_model, D, K, R, P = reachy_sdk.cameras.teleop.get_parameters(CameraView.RIGHT)
+
+    assert height == 720
+    assert width == 960
+    assert distortion_model == "equidistant"
+    assert len(D) == 4
+    assert len(K) == 9
+    assert len(R) == 9
+    assert len(P) == 12

--- a/tests/units/online/test_camera.py
+++ b/tests/units/online/test_camera.py
@@ -16,6 +16,10 @@ def test_no_camera(reachy_sdk: ReachySDK) -> None:
 
     assert res is None
 
+    res = reachy_sdk.cameras.teleop.get_parameters()
+
+    assert res is None
+
 
 """
 @pytest.mark.sr_camera

--- a/tests/units/online/test_camera.py
+++ b/tests/units/online/test_camera.py
@@ -10,9 +10,11 @@ from reachy2_sdk.reachy_sdk import ReachySDK
 
 @pytest.mark.online
 def test_no_camera(reachy_sdk: ReachySDK) -> None:
-    assert reachy_sdk.cameras.teleop is None
+    assert reachy_sdk.cameras.teleop is not None
 
-    assert reachy_sdk.cameras.SR is None
+    res = reachy_sdk.cameras.teleop.get_frame()
+
+    assert res is None
 
 
 """


### PR DESCRIPTION
Minor fix of the unit test related to the change to ROS system.
Camera is always "on" from the SDK point of view. But get_frame and get_parameters will return None