### PR TITLE
345 bug with send goal positions on both arms

### DIFF
--- a/src/reachy2_sdk/orbita/orbita2d.py
+++ b/src/reachy2_sdk/orbita/orbita2d.py
@@ -130,22 +130,23 @@ class Orbita2d(Orbita):
         super().__setattr__(__name, __value)
 
     def send_goal_positions(self) -> None:
-        req_pos = {}
-        for joint_axis in self._joints.keys():
-            if joint_axis in self._outgoing_goal_positions:
-                req_pos[joint_axis] = FloatValue(value=self._outgoing_goal_positions[joint_axis])
-        pose = Pose2d(**req_pos)
+        if self._outgoing_goal_positions:
+            req_pos = {}
+            for joint_axis in self._joints.keys():
+                if joint_axis in self._outgoing_goal_positions:
+                    req_pos[joint_axis] = FloatValue(value=self._outgoing_goal_positions[joint_axis])
+            pose = Pose2d(**req_pos)
 
-        command = Orbita2dsCommand(
-            cmd=[
-                Orbita2dCommand(
-                    id=ComponentId(id=self._id),
-                    goal_position=pose,
-                )
-            ]
-        )
-        self._outgoing_goal_positions = {}
-        self._stub.SendCommand(command)
+            command = Orbita2dsCommand(
+                cmd=[
+                    Orbita2dCommand(
+                        id=ComponentId(id=self._id),
+                        goal_position=pose,
+                    )
+                ]
+            )
+            self._outgoing_goal_positions = {}
+            self._stub.SendCommand(command)
 
     def set_speed_limits(self, speed_limit: float | int) -> None:
         """Set a speed_limit as a percentage of the max speed on all motors of the actuator"""

--- a/src/reachy2_sdk/orbita/orbita3d.py
+++ b/src/reachy2_sdk/orbita/orbita3d.py
@@ -122,22 +122,23 @@ class Orbita3d(Orbita):
         return self._yaw
 
     def send_goal_positions(self) -> None:
-        req_pos = {}
-        for joint_axis in self._joints.keys():
-            if joint_axis in self._outgoing_goal_positions:
-                req_pos[joint_axis] = FloatValue(value=self._outgoing_goal_positions[joint_axis])
-        pose = Rotation3d(rpy=ExtEulerAngles(**req_pos))
+        if self._outgoing_goal_positions:
+            req_pos = {}
+            for joint_axis in self._joints.keys():
+                if joint_axis in self._outgoing_goal_positions:
+                    req_pos[joint_axis] = FloatValue(value=self._outgoing_goal_positions[joint_axis])
+            pose = Rotation3d(rpy=ExtEulerAngles(**req_pos))
 
-        command = Orbita3dsCommand(
-            cmd=[
-                Orbita3dCommand(
-                    id=ComponentId(id=self._id),
-                    goal_position=pose,
-                )
-            ]
-        )
-        self._outgoing_goal_positions = {}
-        self._stub.SendCommand(command)
+            command = Orbita3dsCommand(
+                cmd=[
+                    Orbita3dCommand(
+                        id=ComponentId(id=self._id),
+                        goal_position=pose,
+                    )
+                ]
+            )
+            self._outgoing_goal_positions = {}
+            self._stub.SendCommand(command)
 
     def set_speed_limits(self, speed_limit: float | int) -> None:
         """Set a speed_limit as a percentage of the max speed on all motors of the actuator"""

--- a/tests/units/online/test_basic_movements.py
+++ b/tests/units/online/test_basic_movements.py
@@ -96,8 +96,8 @@ def test_head_movements(reachy_sdk_zeroed: ReachySDK) -> None:
     q1 = reachy_sdk_zeroed.head.get_orientation()
     assert np.isclose(Quaternion.distance(q0, q1), 0, atol=1e-04)
 
-    id = reachy_sdk_zeroed.head.goto_joints([0, 60, 0], duration=1)
-    q2 = Quaternion(axis=[0, 1, 0], degrees=70)  # 10 degrees between joint and cartesian spaces
+    id = reachy_sdk_zeroed.head.goto_joints([0, 40, 0], duration=1)
+    q2 = Quaternion(axis=[0, 1, 0], degrees=50)  # 10 degrees between joint and cartesian spaces
 
     while not is_goto_finished(reachy_sdk_zeroed, id):
         time.sleep(0.1)


### PR DESCRIPTION
- Fix the problem: messages were sent even when _outgoing_goal_positions was empty
- Add test using both arms at the same time with send_goal_positions

Can be tested with `pytest -k test_send_goal_positions`