### PR TITLE
347 add init function

### DIFF
--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -544,6 +544,17 @@ class ReachySDK:
         )
         return ids
 
+    def reset_default_limits(self) -> None:
+        if not self.info:
+            self._logger.warning("Reachy is not connected!")
+            return
+
+        for part in self.info._enabled_parts.values():
+            if issubclass(type(part), JointsBasedPart):
+                part.set_speed_limits(100)
+                part.set_torque_limits(100)
+        time.sleep(0.5)
+
     def is_move_finished(self, id: GoToId) -> bool:
         """Return True if goto has been played and has been cancelled, False otherwise."""
         if not self._grpc_connected:

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -545,6 +545,7 @@ class ReachySDK:
         return ids
 
     def reset_default_limits(self) -> None:
+        """Set back speed and torque limits of all parts to maximum value (100)."""
         if not self.info:
             self._logger.warning("Reachy is not connected!")
             return

--- a/tests/units/online/test_actuators_properties.py
+++ b/tests/units/online/test_actuators_properties.py
@@ -84,6 +84,13 @@ def test_torque_limits(reachy_sdk_zeroed: ReachySDK) -> None:
     assert w_torques["motor_2"] == 90
     assert w_torques["motor_3"] == 90
 
+    reachy_sdk_zeroed.head.neck.set_torque_limits(30)
+    time.sleep(0.2)
+    n_torques = reachy_sdk_zeroed.head.neck.get_torque_limits()
+    assert n_torques["motor_1"] == 30
+    assert n_torques["motor_2"] == 30
+    assert n_torques["motor_3"] == 30
+
 
 @pytest.mark.online
 def test_speed_limits(reachy_sdk_zeroed: ReachySDK) -> None:
@@ -112,3 +119,87 @@ def test_speed_limits(reachy_sdk_zeroed: ReachySDK) -> None:
     assert w_speeds["motor_1"] == 70
     assert w_speeds["motor_2"] == 70
     assert w_speeds["motor_3"] == 70
+
+    reachy_sdk_zeroed.head.neck.set_speed_limits(30)
+    time.sleep(0.2)
+    n_speeds = reachy_sdk_zeroed.head.neck.get_speed_limits()
+    assert n_speeds["motor_1"] == 30
+    assert n_speeds["motor_2"] == 30
+    assert n_speeds["motor_3"] == 30
+
+
+@pytest.mark.online
+def test_reset_default_limits(reachy_sdk_zeroed: ReachySDK) -> None:
+    reachy_sdk_zeroed.l_arm.set_speed_limits(70)
+    reachy_sdk_zeroed.l_arm.set_torque_limits(70)
+    reachy_sdk_zeroed.r_arm.set_speed_limits(50)
+    reachy_sdk_zeroed.r_arm.set_torque_limits(50)
+    reachy_sdk_zeroed.head.neck.set_torque_limits(40)
+    reachy_sdk_zeroed.head.neck.set_speed_limits(40)
+    time.sleep(0.2)
+
+    assert reachy_sdk_zeroed.l_arm.shoulder.get_speed_limits()['motor_1'] == 70
+    assert reachy_sdk_zeroed.l_arm.elbow.get_torque_limits()['motor_2'] == 70
+    assert reachy_sdk_zeroed.r_arm.elbow.get_speed_limits()['motor_1'] == 50
+    assert reachy_sdk_zeroed.r_arm.wrist.get_torque_limits()['motor_3'] == 50
+    print(reachy_sdk_zeroed.head.neck.get_torque_limits())
+    print(reachy_sdk_zeroed.r_arm.wrist.get_torque_limits())
+
+    assert reachy_sdk_zeroed.head.neck.get_torque_limits()['motor_2'] == 40
+    assert reachy_sdk_zeroed.head.neck.get_speed_limits()['motor_3'] == 40
+
+    reachy_sdk_zeroed.reset_default_limits()
+
+    s_l_speeds = reachy_sdk_zeroed.l_arm.shoulder.get_speed_limits()
+    e_l_speeds = reachy_sdk_zeroed.l_arm.elbow.get_speed_limits()
+    w_l_speeds = reachy_sdk_zeroed.l_arm.wrist.get_speed_limits()
+    assert s_l_speeds["motor_1"] == 100
+    assert s_l_speeds["motor_2"] == 100
+    assert e_l_speeds["motor_1"] == 100
+    assert e_l_speeds["motor_2"] == 100
+    assert w_l_speeds["motor_1"] == 100
+    assert w_l_speeds["motor_2"] == 100
+    assert w_l_speeds["motor_3"] == 100
+
+    s_r_speeds = reachy_sdk_zeroed.r_arm.shoulder.get_speed_limits()
+    e_r_speeds = reachy_sdk_zeroed.r_arm.elbow.get_speed_limits()
+    w_r_speeds = reachy_sdk_zeroed.r_arm.wrist.get_speed_limits()
+    assert s_r_speeds["motor_1"] == 100
+    assert s_r_speeds["motor_2"] == 100
+    assert e_r_speeds["motor_1"] == 100
+    assert e_r_speeds["motor_2"] == 100
+    assert w_r_speeds["motor_1"] == 100
+    assert w_r_speeds["motor_2"] == 100
+    assert w_r_speeds["motor_3"] == 100
+
+    h_speeds = reachy_sdk_zeroed.head.neck.get_speed_limits()
+    assert h_speeds["motor_1"] == 100
+    assert h_speeds["motor_2"] == 100
+    assert h_speeds["motor_3"] == 100
+
+    s_l_torques = reachy_sdk_zeroed.l_arm.shoulder.get_torque_limits()
+    e_l_torques = reachy_sdk_zeroed.l_arm.elbow.get_torque_limits()
+    w_l_torques = reachy_sdk_zeroed.l_arm.wrist.get_torque_limits()
+    assert s_l_torques["motor_1"] == 100
+    assert s_l_torques["motor_2"] == 100
+    assert e_l_torques["motor_1"] == 100
+    assert e_l_torques["motor_2"] == 100
+    assert w_l_torques["motor_1"] == 100
+    assert w_l_torques["motor_2"] == 100
+    assert w_l_torques["motor_3"] == 100
+
+    s_r_torques = reachy_sdk_zeroed.r_arm.shoulder.get_torque_limits()
+    e_r_torques = reachy_sdk_zeroed.r_arm.elbow.get_torque_limits()
+    w_r_torques = reachy_sdk_zeroed.r_arm.wrist.get_torque_limits()
+    assert s_r_torques["motor_1"] == 100
+    assert s_r_torques["motor_2"] == 100
+    assert e_r_torques["motor_1"] == 100
+    assert e_r_torques["motor_2"] == 100
+    assert w_r_torques["motor_1"] == 100
+    assert w_r_torques["motor_2"] == 100
+    assert w_r_torques["motor_3"] == 100
+
+    h_torques = reachy_sdk_zeroed.head.neck.get_torque_limits()
+    assert h_torques["motor_1"] == 100
+    assert h_torques["motor_2"] == 100
+    assert h_torques["motor_3"] == 100

--- a/tests/units/online/test_actuators_properties.py
+++ b/tests/units/online/test_actuators_properties.py
@@ -142,8 +142,6 @@ def test_reset_default_limits(reachy_sdk_zeroed: ReachySDK) -> None:
     assert reachy_sdk_zeroed.l_arm.elbow.get_torque_limits()["motor_2"] == 70
     assert reachy_sdk_zeroed.r_arm.elbow.get_speed_limits()["motor_1"] == 50
     assert reachy_sdk_zeroed.r_arm.wrist.get_torque_limits()["motor_3"] == 50
-    print(reachy_sdk_zeroed.head.neck.get_torque_limits())
-    print(reachy_sdk_zeroed.r_arm.wrist.get_torque_limits())
 
     assert reachy_sdk_zeroed.head.neck.get_torque_limits()["motor_2"] == 40
     assert reachy_sdk_zeroed.head.neck.get_speed_limits()["motor_3"] == 40

--- a/tests/units/online/test_actuators_properties.py
+++ b/tests/units/online/test_actuators_properties.py
@@ -138,15 +138,15 @@ def test_reset_default_limits(reachy_sdk_zeroed: ReachySDK) -> None:
     reachy_sdk_zeroed.head.neck.set_speed_limits(40)
     time.sleep(0.2)
 
-    assert reachy_sdk_zeroed.l_arm.shoulder.get_speed_limits()['motor_1'] == 70
-    assert reachy_sdk_zeroed.l_arm.elbow.get_torque_limits()['motor_2'] == 70
-    assert reachy_sdk_zeroed.r_arm.elbow.get_speed_limits()['motor_1'] == 50
-    assert reachy_sdk_zeroed.r_arm.wrist.get_torque_limits()['motor_3'] == 50
+    assert reachy_sdk_zeroed.l_arm.shoulder.get_speed_limits()["motor_1"] == 70
+    assert reachy_sdk_zeroed.l_arm.elbow.get_torque_limits()["motor_2"] == 70
+    assert reachy_sdk_zeroed.r_arm.elbow.get_speed_limits()["motor_1"] == 50
+    assert reachy_sdk_zeroed.r_arm.wrist.get_torque_limits()["motor_3"] == 50
     print(reachy_sdk_zeroed.head.neck.get_torque_limits())
     print(reachy_sdk_zeroed.r_arm.wrist.get_torque_limits())
 
-    assert reachy_sdk_zeroed.head.neck.get_torque_limits()['motor_2'] == 40
-    assert reachy_sdk_zeroed.head.neck.get_speed_limits()['motor_3'] == 40
+    assert reachy_sdk_zeroed.head.neck.get_torque_limits()["motor_2"] == 40
+    assert reachy_sdk_zeroed.head.neck.get_speed_limits()["motor_3"] == 40
 
     reachy_sdk_zeroed.reset_default_limits()
 


### PR DESCRIPTION
Add function to reinit the values of speed and torque limits on the robot
Call `reachy.reset_default_limits()` to set back speed and torque limits to 100

Note : tests do not work as head returns "inf" for speed and torque limits on fake robot.