### PR TITLE
Add translation and rotation examples

### DIFF
--- a/src/examples/3_arm_and_gripper.ipynb
+++ b/src/examples/3_arm_and_gripper.ipynb
@@ -608,7 +608,7 @@
    "id": "d7c76b82",
    "metadata": {},
    "source": [
-    "If you want to compute a translation or rotation without making the robot move, you can call `get_translation_by(...)` and `get_rotation_by(...)` to get the pose 4x4 matrix you would obtain:"
+    "If you want to compute a translation or rotation without making the robot move, you can call `get_translation_by(...)` and `get_rotation_by(...)` to get the corresponding pose 4x4 matrix:"
    ]
   },
   {

--- a/src/examples/3_arm_and_gripper.ipynb
+++ b/src/examples/3_arm_and_gripper.ipynb
@@ -42,7 +42,7 @@
     "from reachy2_sdk import ReachySDK\n",
     "import time\n",
     "\n",
-    "reachy = ReachySDK(host='localhost')  # Replace with the actual IP"
+    "reachy = ReachySDK(host='10.0.0.254')  # Replace with the actual IP"
    ]
   },
   {
@@ -160,7 +160,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reachy.r_arm.get_joints_positions()"
+    "reachy.r_arm.get_joints_positions(round=3)"
    ]
   },
   {
@@ -170,7 +170,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reachy.l_arm.get_joints_positions()"
+    "reachy.l_arm.get_joints_positions(round=3)"
    ]
   },
   {
@@ -196,7 +196,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "elbow_at_90_deg = [0, 0, 0, -90, 0, 0, 0] # only the elbow is set"
+    "r_elbow_at_90_deg = [0, -15, -15, -90, 0, 0, 0]\n",
+    "l_elbow_at_90_deg = [0, 15, 15, -90, 0, 0, 0]"
    ]
   },
   {
@@ -214,8 +215,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reachy.r_arm.goto_joints(elbow_at_90_deg)\n",
-    "reachy.l_arm.goto_joints(elbow_at_90_deg)\n",
+    "reachy.r_arm.goto_joints(r_elbow_at_90_deg)\n",
+    "reachy.l_arm.goto_joints(l_elbow_at_90_deg)\n",
     "while reachy.r_arm.get_move_playing().id != -1:\n",
     "    time.sleep(0.5)"
    ]
@@ -386,9 +387,10 @@
    "source": [
     "import numpy as np\n",
     "target = np.identity(4)\n",
-    "target[0][3] = 0.4 # x\n",
-    "target[1][3] = 0.1 # y\n",
-    "target[2][3] = -0.3 # z\n",
+    "target = np.array([[0, 0, -1, 0.3],\n",
+    "    [0, 1, 0, 0.1],\n",
+    "    [1, 0, 0, -0.3],\n",
+    "    [0, 0, 0, 1]])\n",
     "target"
    ]
   },
@@ -420,7 +422,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "reachy.set_pose(\"default\")\n",
+    "reachy.l_arm.set_pose(\"default\")\n",
     "reachy.l_arm.goto_from_matrix(target)\n",
     "\n",
     "while reachy.l_arm.get_move_playing().id != -1:\n",
@@ -437,7 +439,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "689dd408",
+   "id": "c731a553",
    "metadata": {},
    "source": [
     "### Cartesian space"
@@ -445,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f526bb56",
+   "id": "84e1c9ec",
    "metadata": {},
    "source": [
     "Controlling the arm in cartesian space allows you to control the position of the gripper in Reachy's coordinate system. It is the recommended way to control the robot for grasping goals.  \n",
@@ -455,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b72d21b",
+   "id": "3a2d1aef",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +469,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3fc755aa",
+   "id": "79eb24c9",
    "metadata": {},
    "source": [
     "You can easily access the current pose of the gripper using the previously seen method `forward_kinematics()`"
@@ -476,7 +478,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c36e908d",
+   "id": "99f5e078",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +488,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42d6d91c",
+   "id": "4c24ea5b",
    "metadata": {},
    "source": [
     "#### Move the arms in cartesian space"
@@ -494,7 +496,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "172b99ea",
+   "id": "5c2d8f96",
    "metadata": {},
    "source": [
     "To control the arm in cartesian space, use the `goto_from_matrix(...)` method.  \n",
@@ -504,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50aabd42",
+   "id": "287809df",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,7 +515,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e6b38d8",
+   "id": "e8e8f6e0",
    "metadata": {},
    "source": [
     "As you have just seen, the arm moved meanwhile the gripper is in the exact same position and orientation: that's because the computed inverse kinematics solution is different from the joints we decided to choose in joint space (`set_pose()` is in fact a joint space method).  \n",
@@ -525,7 +527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a535b13",
+   "id": "44b3b11e",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +538,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c4ffb92",
+   "id": "86dcfc37",
    "metadata": {},
    "source": [
     "This new_pose is translated 10cm front in Reachy's coordinate system (+10cm on Reachy's x axis).  \n",
@@ -546,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40399c74",
+   "id": "529c47bb",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "edd7435e",
+   "id": "8fdc8d70",
    "metadata": {},
    "source": [
     "To simplify your life, you have access to functions to easily compute translation or rotation.  \n",
@@ -565,7 +567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f0b64ba",
+   "id": "a25aad8c",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,7 +576,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "821e53c0",
+   "id": "362b1464",
    "metadata": {},
    "source": [
     "You can easily make the gripper rotate with the `rotate_by(...)` method:"
@@ -583,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1e77520",
+   "id": "35460f73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +594,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c573ed40",
+   "id": "f43bdfba",
    "metadata": {},
    "source": [
     "The gripper rotate by 10 degrees around the x axis of the gripper.  \n",
@@ -603,7 +605,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33a8e37a",
+   "id": "d7c76b82",
    "metadata": {},
    "source": [
     "If you want to compute a translation or rotation without making the robot move, you can call `get_translation_by(...)` and `get_rotation_by(...)` to get the pose 4x4 matrix you would obtain:"
@@ -612,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5022536",
+   "id": "909bef89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,11 +624,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155cc93a",
+   "id": "7c7e34f7",
    "metadata": {},
    "outputs": [],
    "source": [
-    "reachy.l_arm.get_roation_by(-10, 20, 0, frame='gripper')"
+    "reachy.l_arm.get_rotation_by(-10, 20, 0, frame='gripper')"
    ]
   },
   {
@@ -699,12 +701,6 @@
     "    \n",
     "reachy.turn_off_smoothly()"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "49",
-   "metadata": {},
-   "source": []
   }
  ],
  "metadata": {

--- a/src/examples/3_arm_and_gripper.ipynb
+++ b/src/examples/3_arm_and_gripper.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "0",
    "metadata": {},
@@ -10,7 +9,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "1",
    "metadata": {},
@@ -19,7 +17,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "2",
    "metadata": {},
@@ -28,7 +25,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "3",
    "metadata": {},
@@ -50,7 +46,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "5",
    "metadata": {},
@@ -70,7 +65,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "7",
    "metadata": {},
@@ -91,16 +85,30 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "9",
+   "id": "67c111a8",
    "metadata": {},
    "source": [
-    "## Check Arm Joints"
+    "## Control the arms\n",
+    "\n",
+    "Arms can be controlled in two spaces:\n",
+    "\n",
+    "* the **joint space**, which allows to read and write directly the angle values of each joint of the arm\n",
+    "* the **cartesian space**, which consists in controlling the end effector position and orientation in Reachy's coordinate system\n",
+    "\n",
+    "> Both spaces are quite different, and **we advise not to mix them** if you are not familiar with the output.\n",
+    "In fact, values of the joint space are expressed in each actuator (respectively shoulder, elbow and wrist), whereas commands in cartesian space are expressed in Reachy's coordinate system"
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "id": "90eb021f",
+   "metadata": {},
+   "source": [
+    "### Joint space"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "10",
    "metadata": {},
@@ -112,7 +120,7 @@
     "- wrist, composed of 3 joints (roll, pitch and yaw)\n",
     "\n",
     "We refer to the shoulder, elbow and wrist as actuators.\n",
-    "For some actions, such as changing the compliancy, is the the lowest level of control you will have.\n",
+    "For some actions, such as changing the compliancy, it is the lowest level of control you will have.\n",
     "\n",
     "You can inspect the details of the arm with:"
    ]
@@ -138,7 +146,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "13",
    "metadata": {},
@@ -167,16 +174,14 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "16",
    "metadata": {},
    "source": [
-    "## Move the Arms"
+    "#### Move the arms in joint space"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "17",
    "metadata": {},
@@ -195,7 +200,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "19",
    "metadata": {},
@@ -217,7 +221,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "21",
    "metadata": {},
@@ -239,7 +242,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "23",
    "metadata": {},
@@ -265,7 +267,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "25",
    "metadata": {},
@@ -275,7 +276,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "26",
    "metadata": {},
@@ -286,16 +286,14 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "27",
+   "id": "9495ca66",
    "metadata": {},
    "source": [
-    "## Kinematics"
+    "### Kinematics"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "28",
    "metadata": {},
@@ -306,20 +304,20 @@
     "\n",
     "[Long story](https://docs.pollen-robotics.com/sdk/first-moves/kinematics/) short, there are two types of kinematics:\n",
     "- Forward kinematics: from the joints position, the position in space of the gripper is computed\n",
-    "- Inverse kinematics: from a given position of the gripper to reach, all joints positions are computed"
+    "- Inverse kinematics: from a given position of the gripper to reach, all joints positions are computed\n",
+    "\n",
+    "> You can easily use forward kinematics and inverse kinematics to switch respectively from joint space to cartesian space and from cartesian space to joint space."
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "29",
    "metadata": {},
    "source": [
-    "### Forward Kinematics"
+    "#### Forward Kinematics"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "30",
    "metadata": {},
@@ -338,7 +336,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "32",
    "metadata": {},
@@ -357,7 +354,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "34",
    "metadata": {},
@@ -366,16 +362,14 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "35",
    "metadata": {},
    "source": [
-    "### Inverse Kinematics"
+    "#### Inverse Kinematics"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "36",
    "metadata": {},
@@ -427,11 +421,13 @@
    "outputs": [],
    "source": [
     "reachy.set_pose(\"default\")\n",
-    "reachy.l_arm.goto_from_matrix(target)"
+    "reachy.l_arm.goto_from_matrix(target)\n",
+    "\n",
+    "while reachy.l_arm.get_move_playing().id != -1:\n",
+    "    time.sleep(0.5)"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "41",
    "metadata": {},
@@ -440,7 +436,200 @@
    ]
   },
   {
-   "attachments": {},
+   "cell_type": "markdown",
+   "id": "689dd408",
+   "metadata": {},
+   "source": [
+    "### Cartesian space"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f526bb56",
+   "metadata": {},
+   "source": [
+    "Controlling the arm in cartesian space allows you to control the position of the gripper in Reachy's coordinate system. It is the recommended way to control the robot for grasping goals.  \n",
+    "Let's got back to the *elbow_90* pose:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b72d21b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reachy.l_arm.set_pose('elbow_90')\n",
+    "\n",
+    "while reachy.l_arm.get_move_playing().id != -1:\n",
+    "    time.sleep(0.5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fc755aa",
+   "metadata": {},
+   "source": [
+    "You can easily access the current pose of the gripper using the previously seen method `forward_kinematics()`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c36e908d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "current_pose = reachy.l_arm.forward_kinematics()\n",
+    "print(current_pose)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42d6d91c",
+   "metadata": {},
+   "source": [
+    "#### Move the arms in cartesian space"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "172b99ea",
+   "metadata": {},
+   "source": [
+    "To control the arm in cartesian space, use the `goto_from_matrix(...)` method.  \n",
+    "Let's use it on the current_pose:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50aabd42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reachy.l_arm.goto_from_matrix(current_pose)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e6b38d8",
+   "metadata": {},
+   "source": [
+    "As you have just seen, the arm moved meanwhile the gripper is in the exact same position and orientation: that's because the computed inverse kinematics solution is different from the joints we decided to choose in joint space (`set_pose()` is in fact a joint space method).  \n",
+    "\n",
+    "Let's send the arm to a new goal pose.  \n",
+    "We need to define a pose 4x4 matrix as the new goal pose for the gripper:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a535b13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "new_pose = current_pose.copy()\n",
+    "new_pose[0, 3] += 0.1\n",
+    "print(new_pose)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c4ffb92",
+   "metadata": {},
+   "source": [
+    "This new_pose is translated 10cm front in Reachy's coordinate system (+10cm on Reachy's x axis).  \n",
+    "You can send it to the robot:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40399c74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reachy.l_arm.goto_from_matrix(new_pose)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "edd7435e",
+   "metadata": {},
+   "source": [
+    "To simplify your life, you have access to functions to easily compute translation or rotation.  \n",
+    "Use the `translate_by(...)` method to send the gripper back to the previous pose, asking for a translation 10cm back (-10cm on Reachy's x axis):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f0b64ba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reachy.l_arm.translate_by(-0.1, 0, 0, frame='robot')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "821e53c0",
+   "metadata": {},
+   "source": [
+    "You can easily make the gripper rotate with the `rotate_by(...)` method:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f1e77520",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reachy.l_arm.rotate_by(10, 0, 0, frame='gripper')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c573ed40",
+   "metadata": {},
+   "source": [
+    "The gripper rotate by 10 degrees around the x axis of the gripper.  \n",
+    "For both functions, you need to specify a frame:\n",
+    "* setting **gripper** as frame will translate or rotate in the gripper coordinate system\n",
+    "* setting **robot** as frame will translate or rotate directly in Reachy's coordinate system"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33a8e37a",
+   "metadata": {},
+   "source": [
+    "If you want to compute a translation or rotation without making the robot move, you can call `get_translation_by(...)` and `get_rotation_by(...)` to get the pose 4x4 matrix you would obtain:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b5022536",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reachy.l_arm.get_translation_by(-0.1, 0.2, -0.1, frame='gripper')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "155cc93a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reachy.l_arm.get_roation_by(-10, 20, 0, frame='gripper')"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "42",
    "metadata": {},
@@ -449,7 +638,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "43",
    "metadata": {},
@@ -470,7 +658,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "45",
    "metadata": {},
@@ -491,7 +678,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "47",
    "metadata": {},
@@ -515,7 +701,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "id": "49",
    "metadata": {},
@@ -538,7 +723,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.10.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Modify notebook 3_arm_and_gripper to introduce `rotate_by()`, `translate_by()`, `get_rotation_by()` and `get_translation_by()`