### PR TITLE
391 add utils functions for pose matrix

### DIFF
--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -48,6 +48,8 @@ from ..utils.utils import (
     list_to_arm_position,
     matrix_from_euler_angles,
     recompose_matrix,
+    rotate_in_self,
+    translate_in_self,
 )
 from .goto_based_part import IGoToBasedPart
 from .hand import Hand
@@ -507,11 +509,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
             pose[1, 3] += y
             pose[2, 3] += z
         elif frame == "gripper":
-            translation_matrix = np.eye(4)
-            translation_matrix[0, 3] += x
-            translation_matrix[1, 3] += y
-            translation_matrix[2, 3] += z
-            pose = np.dot(pose, translation_matrix)
+            pose = translate_in_self(initial_pose, [x, y, z])
         return pose
 
     def translate_by(
@@ -581,7 +579,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
             pose_rotation = rotation @ pose_rotation
             pose = recompose_matrix(pose_rotation[:3, :3], pose_translation)
         elif frame == "gripper":
-            pose = pose @ rotation
+            pose = rotate_in_self(initial_pose, [roll, pitch, yaw], degrees=degrees)
 
         return pose
 

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -287,6 +287,52 @@ class Arm(JointsBasedPart, IGoToBasedPart):
             answer = np.round(answer, round).tolist()
         return answer
 
+    def get_default_pose_matrix(self, common_pose: str = "default") -> npt.NDArray[np.float64]:
+        """Return the 4x4 pose matrix of default robot poses."""
+        if common_pose not in ["default", "elbow_90"]:
+            raise ValueError(f"common_pose {common_pose} not supported! Should be 'default' or 'elbow_90'")
+
+        if common_pose == "elbow_90":
+            elbow_pitch = -90
+        else:
+            elbow_pitch = 0
+
+        if self._part_id.name == "r_arm":
+            pose = self.forward_kinematics([0, -15, -15, elbow_pitch, 0, 0, 0])
+        else:
+            pose = self.forward_kinematics([0, 15, 15, elbow_pitch, 0, 0, 0])
+
+        return pose
+
+    def get_pose_matrix(
+        self, position: npt.NDArray[np.float64], rotation: npt.NDArray[np.float64], degrees: bool = True
+    ) -> npt.NDArray[np.float64]:
+        """Creates the 4x4 pose matrix from a position vector and \"roll pitch yaw\" angles (rotation).
+        Arguments :
+            position : a list of size 3. It is the requested position of the end effector in the robot coordinate system
+            rotation : a list of size 3. It it the requested orientation of the end effector in the robot coordinate system.
+                       Rotation is given as intrinsic angles, that are executed in roll, pitch, yaw order.
+            degrees  : True if angles are provided in degrees, False if they are in radians.
+        Returns :
+            pose : the constructed pose matrix. This is a 4x4 numpy array
+        """
+        if not (isinstance(position, np.ndarray) or isinstance(position, list)) or not all(
+            isinstance(pos, float | int) for pos in position
+        ):
+            raise TypeError(f"position should be a list of float, got {position}")
+        if not (isinstance(rotation, np.ndarray) or isinstance(rotation, list)) or not all(
+            isinstance(rot, float | int) for rot in rotation
+        ):
+            raise TypeError(f"rotation should be a list of float, got {rotation}")
+        if len(position) != 3:
+            raise ValueError("position should be a list of len 3")
+        if len(rotation) != 3:
+            raise ValueError("rotation should be a list of len 3")
+
+        pose = matrix_from_euler_angles(rotation[0], rotation[1], rotation[2], degrees=degrees)
+        pose[:3, 3] = np.array(position)
+        return pose
+
     def goto_from_matrix(
         self,
         target: npt.NDArray[np.float64],

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -304,35 +304,6 @@ class Arm(JointsBasedPart, IGoToBasedPart):
 
         return pose
 
-    def get_pose_matrix(
-        self, position: npt.NDArray[np.float64], rotation: npt.NDArray[np.float64], degrees: bool = True
-    ) -> npt.NDArray[np.float64]:
-        """Creates the 4x4 pose matrix from a position vector and \"roll pitch yaw\" angles (rotation).
-        Arguments :
-            position : a list of size 3. It is the requested position of the end effector in the robot coordinate system
-            rotation : a list of size 3. It it the requested orientation of the end effector in the robot coordinate system.
-                       Rotation is given as intrinsic angles, that are executed in roll, pitch, yaw order.
-            degrees  : True if angles are provided in degrees, False if they are in radians.
-        Returns :
-            pose : the constructed pose matrix. This is a 4x4 numpy array
-        """
-        if not (isinstance(position, np.ndarray) or isinstance(position, list)) or not all(
-            isinstance(pos, float | int) for pos in position
-        ):
-            raise TypeError(f"position should be a list of float, got {position}")
-        if not (isinstance(rotation, np.ndarray) or isinstance(rotation, list)) or not all(
-            isinstance(rot, float | int) for rot in rotation
-        ):
-            raise TypeError(f"rotation should be a list of float, got {rotation}")
-        if len(position) != 3:
-            raise ValueError("position should be a list of len 3")
-        if len(rotation) != 3:
-            raise ValueError("rotation should be a list of len 3")
-
-        pose = matrix_from_euler_angles(rotation[0], rotation[1], rotation[2], degrees=degrees)
-        pose[:3, 3] = np.array(position)
-        return pose
-
     def goto_from_matrix(
         self,
         target: npt.NDArray[np.float64],

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -524,7 +524,7 @@ class ReachySDK:
         Otherwise, the commands will be sent to a part when all gotos of its queue has been played.
         """
         if common_pose not in ["default", "elbow_90"]:
-            raise ValueError(f"common_pose {interpolation_mode} not supported! Should be 'default' or 'elbow_90'")
+            raise ValueError(f"common_pose {common_pose} not supported! Should be 'default' or 'elbow_90'")
         head_id = None
         r_arm_id = None
         l_arm_id = None

--- a/src/reachy2_sdk/utils/utils.py
+++ b/src/reachy2_sdk/utils/utils.py
@@ -165,3 +165,33 @@ def matrix_from_euler_angles(roll: float, pitch: float, yaw: float, degrees: boo
 
     rotation_matrix = R_z @ R_y @ R_x
     return rotation_matrix
+
+
+def get_pose_matrix(
+    position: npt.NDArray[np.float64], rotation: npt.NDArray[np.float64], degrees: bool = True
+) -> npt.NDArray[np.float64]:
+    """Creates the 4x4 pose matrix from a position vector and \"roll pitch yaw\" angles (rotation).
+    Arguments :
+        position : a list of size 3. It is the requested position of the end effector in the robot coordinate system
+        rotation : a list of size 3. It it the requested orientation of the end effector in the robot coordinate system.
+                   Rotation is given as intrinsic angles, that are executed in roll, pitch, yaw order.
+        degrees  : True if angles are provided in degrees, False if they are in radians.
+    Returns :
+        pose : the constructed pose matrix. This is a 4x4 numpy array
+    """
+    if not (isinstance(position, np.ndarray) or isinstance(position, list)) or not all(
+        isinstance(pos, float | int) for pos in position
+    ):
+        raise TypeError(f"position should be a list of float, got {position}")
+    if not (isinstance(rotation, np.ndarray) or isinstance(rotation, list)) or not all(
+        isinstance(rot, float | int) for rot in rotation
+    ):
+        raise TypeError(f"rotation should be a list of float, got {rotation}")
+    if len(position) != 3:
+        raise ValueError("position should be a list of len 3")
+    if len(rotation) != 3:
+        raise ValueError("rotation should be a list of len 3")
+
+    pose = matrix_from_euler_angles(rotation[0], rotation[1], rotation[2], degrees=degrees)
+    pose[:3, 3] = np.array(position)
+    return pose

--- a/tests/units/offline/test_utils.py
+++ b/tests/units/offline/test_utils.py
@@ -13,6 +13,8 @@ from reachy2_sdk.utils.utils import (
     get_pose_matrix,
     list_to_arm_position,
     matrix_from_euler_angles,
+    rotate_in_self,
+    translate_in_self,
 )
 
 
@@ -134,3 +136,63 @@ def test_get_pose_matrix() -> None:
         get_pose_matrix([0.1, 0.2, 0.1, 0.1], [0, -90, 0])
     with pytest.raises(ValueError):
         get_pose_matrix([0.1, 0.2, 0.1], [-20, -90, -50, 10])
+
+
+@pytest.mark.offline
+def test_rotate_in_self() -> None:
+    A = get_pose_matrix([0.2, -0.2, -0.1], [0, -90, 0])
+    A_rot = rotate_in_self(A, [0, 20, 0], degrees=True)
+
+    expected_A_rot = np.array(
+        [[0.34202014, 0.0, -0.93969262, 0.2], [0.0, 1.0, 0.0, -0.2], [0.93969262, 0.0, 0.34202014, -0.1], [0.0, 0.0, 0.0, 1.0]]
+    )
+
+    assert np.allclose(A_rot, expected_A_rot, atol=1e-03)
+
+    A2_rot = rotate_in_self(A, [10, 30, -10])
+    expected_A2_rot = np.array(
+        [
+            [0.5, -0.15038373, -0.85286853, 0.2],
+            [-0.15038373, 0.95476947, -0.25651511, -0.2],
+            [0.85286853, 0.25651511, 0.45476947, -0.1],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    assert np.allclose(A2_rot, expected_A2_rot, atol=1e-03)
+
+    B = get_pose_matrix([0.3, 0.2, -0.1], [0, -60, 30])
+    B_rot = rotate_in_self(B, [10, 20, 40], degrees=True)
+    expected_B_rot = np.array(
+        [
+            [0.26620632, -0.77307934, -0.5757452, 0.3],
+            [0.85115971, 0.46885778, -0.23600748, 0.2],
+            [0.45239512, -0.42722444, 0.78282689, -0.1],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    assert np.allclose(B_rot, expected_B_rot, atol=1e-03)
+
+
+@pytest.mark.offline
+def test_translate_in_self() -> None:
+    A = get_pose_matrix([0.2, -0.2, -0.1], [0, -90, 0])
+    A_trans = translate_in_self(A, [0, 0.2, 0])
+
+    expected_A_trans = np.array([[0.0, 0.0, -1.0, 0.2], [0.0, 1.0, 0.0, 0.0], [1.0, 0.0, 0.0, -0.1], [0.0, 0.0, 0.0, 1.0]])
+    assert np.allclose(A_trans, expected_A_trans, atol=1e-03)
+
+    A2_trans = translate_in_self(A, [0.1, 0.3, -0.1])
+    expected_A2_trans = np.array([[0.0, 0.0, -1.0, 0.3], [0.0, 1.0, 0.0, 0.1], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
+    assert np.allclose(A2_trans, expected_A2_trans, atol=1e-03)
+
+    B = get_pose_matrix([0.3, 0.2, -0.1], [0, -60, 30])
+    B_trans = translate_in_self(B, [0.1, -0.2, 0.4])
+    expected_B_trans = np.array(
+        [
+            [0.433012, -0.5, -0.75, 0.1433012],
+            [0.25, 0.866025, -0.433012, -0.12141],
+            [0.866025, 0.0, 0.5, 0.1866025],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    assert np.allclose(B_trans, expected_B_trans, atol=1e-03)

--- a/tests/units/offline/test_utils.py
+++ b/tests/units/offline/test_utils.py
@@ -10,6 +10,7 @@ from reachy2_sdk.utils.utils import (
     ext_euler_angles_to_list,
     get_grpc_interpolation_mode,
     get_interpolation_mode,
+    get_pose_matrix,
     list_to_arm_position,
     matrix_from_euler_angles,
 )
@@ -107,3 +108,29 @@ def test_matrix_from_euler_angles() -> None:
     expected_C = np.eye(4)
     expected_C[:3, :3] = scipy_result_C
     np.array_equal(expected_C, C)
+
+
+@pytest.mark.offline
+def test_get_pose_matrix() -> None:
+    A = np.array([[0.0, 0.0, -1.0, 0.5], [0.0, 1.0, 0.0, 0.1], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
+    pose_A = get_pose_matrix([0.5, 0.1, 0], [0, -90, 0])
+    assert np.allclose(A, pose_A, atol=1e-03)
+
+    B = np.array([[0.0, 1.0, -0.0, 0.2], [0.0, 0.0, 1.0, 0.4], [1.0, -0.0, 0.0, -0.2], [0.0, 0.0, 0.0, 1.0]])
+    pose_B = get_pose_matrix([0.2, 0.4, -0.2], [-90, -90, 0])
+    assert np.allclose(B, pose_B, atol=1e-03)
+
+    C = np.array([[0.262, -0.808, -0.528, 0.5], [0.72, 0.528, -0.451, -0.8], [0.643, -0.262, 0.72, 0.0], [0.0, 0.0, 0.0, 1.0]])
+    pose_C = get_pose_matrix([0.5, -0.8, 0], [-20, -40, 70])
+    assert np.allclose(C, pose_C, atol=1e-03)
+
+    with pytest.raises(TypeError):
+        get_pose_matrix([1, 2, "coucou"], [1, 2, 3])
+    with pytest.raises(TypeError):
+        get_pose_matrix([1, 2, 3], [1, 2, "coucou"])
+    with pytest.raises(TypeError):
+        get_pose_matrix([0.1, 0.2, 0.3], -90)
+    with pytest.raises(ValueError):
+        get_pose_matrix([0.1, 0.2, 0.1, 0.1], [0, -90, 0])
+    with pytest.raises(ValueError):
+        get_pose_matrix([0.1, 0.2, 0.1], [-20, -90, -50, 10])

--- a/tests/units/online/test_basic_movements.py
+++ b/tests/units/online/test_basic_movements.py
@@ -185,7 +185,7 @@ def test_send_goal_positions(reachy_sdk_zeroed: ReachySDK) -> None:
 
 
 @pytest.mark.online
-def test_get_matrix(reachy_sdk_zeroed: ReachySDK) -> None:
+def test_get_default_pose_matrix(reachy_sdk_zeroed: ReachySDK) -> None:
     reachy_sdk_zeroed.set_pose(wait=True)
     r_matrix = reachy_sdk_zeroed.r_arm.get_default_pose_matrix()
     l_matrix = reachy_sdk_zeroed.l_arm.get_default_pose_matrix()
@@ -206,3 +206,20 @@ def test_get_matrix(reachy_sdk_zeroed: ReachySDK) -> None:
 
     with pytest.raises(ValueError):
         reachy_sdk_zeroed.r_arm.get_default_pose_matrix("coucou")
+
+
+@pytest.mark.online
+def test_get_default_pose_joints(reachy_sdk_zeroed: ReachySDK) -> None:
+    r_default_joints_expected = [0, -15, -15, 0, 0, 0, 0]
+    l_default_joints_expected = [0, 15, 15, 0, 0, 0, 0]
+    r_default_joints = reachy_sdk_zeroed.r_arm.get_default_pose_joints(common_pose="default")
+    l_default_joints = reachy_sdk_zeroed.l_arm.get_default_pose_joints(common_pose="default")
+    assert np.allclose(r_default_joints, r_default_joints_expected, atol=1e-03)
+    assert np.allclose(l_default_joints, l_default_joints_expected, atol=1e-03)
+
+    r_elbow_90_joints_expected = [0, -15, -15, -90, 0, 0, 0]
+    l_elbow_90_joints_expected = [0, 15, 15, -90, 0, 0, 0]
+    r_elbow_90_joints = reachy_sdk_zeroed.r_arm.get_default_pose_joints(common_pose="elbow_90")
+    l_elbow_90_joints = reachy_sdk_zeroed.l_arm.get_default_pose_joints(common_pose="elbow_90")
+    assert np.allclose(r_elbow_90_joints, r_elbow_90_joints_expected, atol=1e-03)
+    assert np.allclose(l_elbow_90_joints, l_elbow_90_joints_expected, atol=1e-03)

--- a/tests/units/online/test_basic_movements.py
+++ b/tests/units/online/test_basic_movements.py
@@ -206,26 +206,3 @@ def test_get_matrix(reachy_sdk_zeroed: ReachySDK) -> None:
 
     with pytest.raises(ValueError):
         reachy_sdk_zeroed.r_arm.get_default_pose_matrix("coucou")
-
-    A = np.array([[0.0, 0.0, -1.0, 0.5], [0.0, 1.0, 0.0, 0.1], [1.0, 0.0, 0.0, 0.0], [0.0, 0.0, 0.0, 1.0]])
-    pose_A = reachy_sdk_zeroed.r_arm.get_pose_matrix([0.5, 0.1, 0], [0, -90, 0])
-    assert np.allclose(A, pose_A, atol=1e-03)
-
-    B = np.array([[0.0, 1.0, -0.0, 0.2], [0.0, 0.0, 1.0, 0.4], [1.0, -0.0, 0.0, -0.2], [0.0, 0.0, 0.0, 1.0]])
-    pose_B = reachy_sdk_zeroed.r_arm.get_pose_matrix([0.2, 0.4, -0.2], [-90, -90, 0])
-    assert np.allclose(B, pose_B, atol=1e-03)
-
-    C = np.array([[0.262, -0.808, -0.528, 0.5], [0.72, 0.528, -0.451, -0.8], [0.643, -0.262, 0.72, 0.0], [0.0, 0.0, 0.0, 1.0]])
-    pose_C = reachy_sdk_zeroed.r_arm.get_pose_matrix([0.5, -0.8, 0], [-20, -40, 70])
-    assert np.allclose(C, pose_C, atol=1e-03)
-
-    with pytest.raises(TypeError):
-        reachy_sdk_zeroed.r_arm.get_pose_matrix([1, 2, "coucou"], [1, 2, 3])
-    with pytest.raises(TypeError):
-        reachy_sdk_zeroed.r_arm.get_pose_matrix([1, 2, 3], [1, 2, "coucou"])
-    with pytest.raises(TypeError):
-        reachy_sdk_zeroed.r_arm.get_pose_matrix([0.1, 0.2, 0.3], -90)
-    with pytest.raises(ValueError):
-        reachy_sdk_zeroed.r_arm.get_pose_matrix([0.1, 0.2, 0.1, 0.1], [0, -90, 0])
-    with pytest.raises(ValueError):
-        reachy_sdk_zeroed.r_arm.get_pose_matrix([0.1, 0.2, 0.1], [-20, -90, -50, 10])


### PR DESCRIPTION
Add of 2 utils functions to create matrix pose for the arms : 
- `reachy.r_arm.get_default_pose_matrix()`, which takes the same common_pose as `set_pose()`
- `reachy.r_arm.get_pose_matrix([x, y, z], [roll, pitch, yaw])` to create matrix the way they use `make_pose` in the tuto

Not sure arm.py is the right place.