### PR TITLE
393 add translate by and rotate by to mobile base

### DIFF
--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -180,15 +180,18 @@ class MobileBase(Part):
         odometry = self.odometry
         x = odometry["x"] + x
         y = odometry["y"] + y
-        self.goto(x, y, 0, timeout=timeout)
+        theta = odometry["theta"]
+        self.goto(x, y, theta, timeout=timeout)
 
     def rotate_by(self, theta: float, timeout: Optional[float] = None) -> None:
         """Send a target rotation relative to the current rotation of the mobile base.
 
         theta defines the rotation wanted in the mobile base in cartesian space."""
         odometry = self.odometry
+        x = odometry["x"]
+        y = odometry["y"]
         theta = odometry["theta"] + theta
-        self.goto(0, 0, theta, timeout=timeout)
+        self.goto(x, y, theta, timeout=timeout)
 
     def goto(
         self,

--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -173,6 +173,15 @@ class MobileBase(Part):
         )
         self._mobility_stub.SendDirection(req)
 
+    def translate_by(self, x: float, y: float, timeout: Optional[float] = None) -> None:
+        """Send a target position relative to the current position of the mobile base.
+
+        (x, y) define the translation wanted in the mobile base in cartesian space."""
+        odometry = self.odometry
+        x = odometry["x"] + x
+        y = odometry["y"] + y
+        self.goto(x, y, 0, timeout=timeout)
+
     def rotate_by(self, theta: float, timeout: Optional[float] = None) -> None:
         """Send a target rotation relative to the current rotation of the mobile base.
 

--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -173,6 +173,14 @@ class MobileBase(Part):
         )
         self._mobility_stub.SendDirection(req)
 
+    def rotate_by(self, theta: float, timeout: Optional[float] = None) -> None:
+        """Send a target rotation relative to the current rotation of the mobile base.
+
+        theta defines the rotation wanted in the mobile base in cartesian space."""
+        odometry = self.odometry
+        theta = odometry["theta"] + theta
+        self.goto(0, 0, theta, timeout=timeout)
+
     def goto(
         self,
         x: float,

--- a/tests/units/online/test_advanced_goto_functions.py
+++ b/tests/units/online/test_advanced_goto_functions.py
@@ -455,6 +455,7 @@ def test_wait_move(reachy_sdk_zeroed: ReachySDK) -> None:
     assert np.isclose(elapsed_time, 3.0, 1e-01)
 
     reachy_sdk_zeroed.r_arm.goto_joints([0, 10, 20, -40, 10, 10, -15], duration=4)
+    time.sleep(0.1)
 
     assert reachy_sdk_zeroed.head.get_move_playing().id != -1
     assert reachy_sdk_zeroed.l_arm.get_move_playing().id == -1


### PR DESCRIPTION
Add new functions `reachy.mobile_base.translate_by(x, y)` and `reachy.mobile_base.rotate_by(x, y)`.

No test has been added as the mobile base movements are not simulated so far.

:warning: WARNING : Not tested on the robot so far