### PR TITLE
Circular interpolation

### DIFF
--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -569,7 +569,8 @@ class Arm(JointsBasedPart, IGoToBasedPart):
                 normal = np.cross(vector, [1, 0, 0])
             case _:
                 raise ValueError(
-                    "arc_direction {arc_direction} not supported ! Should be one of: 'above', 'below', 'front', 'back', 'right' or 'left'"
+                    f"arc_direction '{arc_direction}' not supported! Should be one of: "
+                    "'above', 'below', 'front', 'back', 'right' or 'left'"
                 )
 
         if np.linalg.norm(normal) == 0:

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -544,16 +544,28 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         """Get a normal vector to the given vector in the desired direction."""
         match arc_direction:
             case "above":
+                if vector[0] < 0.001 and vector[1] < 0.001:
+                    return None
                 normal = np.cross(vector, [0, 0, -1])
             case "below":
+                if vector[0] < 0.001 and vector[1] < 0.001:
+                    return None
                 normal = np.cross(vector, [0, 0, 1])
             case "left":
+                if vector[0] < 0.001 and vector[2] < 0.001:
+                    return None
                 normal = np.cross(vector, [0, -1, 0])
             case "right":
+                if vector[0] < 0.001 and vector[2] < 0.001:
+                    return None
                 normal = np.cross(vector, [0, 1, 0])
             case "front":
+                if vector[1] < 0.001 and vector[2] < 0.001:
+                    return None
                 normal = np.cross(vector, [-1, 0, 0])
             case "back":
+                if vector[1] < 0.001 and vector[2] < 0.001:
+                    return None
                 normal = np.cross(vector, [1, 0, 0])
 
         if np.linalg.norm(normal) == 0:

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -440,8 +440,6 @@ class Arm(JointsBasedPart, IGoToBasedPart):
                         angle2 += 2 * np.pi
                 if angle1 < angle2:
                     angle1, angle2 = angle2, angle1
-            
-            interpolated_matrices = []
         
             # Interpolation linéaire sur l'arc du cercle et SLERP pour la rotation
             for t in np.linspace(0, 1, nb_steps):

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -376,7 +376,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         try:
             self.inverse_kinematics(target)
         except ValueError:
-            raise ValueError("Target pose is not reachable!")
+            raise ValueError(f"Target pose: \n{target}\n is not reachable!")
 
         origin_matrix = self.forward_kinematics()
         nb_steps = int(duration * interpolation_frequency)
@@ -544,29 +544,33 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         """Get a normal vector to the given vector in the desired direction."""
         match arc_direction:
             case "above":
-                if vector[0] < 0.001 and vector[1] < 0.001:
+                if abs(vector[0]) < 0.001 and abs(vector[1]) < 0.001:
                     return None
                 normal = np.cross(vector, [0, 0, -1])
             case "below":
-                if vector[0] < 0.001 and vector[1] < 0.001:
+                if abs(vector[0]) < 0.001 and abs(vector[1]) < 0.001:
                     return None
                 normal = np.cross(vector, [0, 0, 1])
             case "left":
-                if vector[0] < 0.001 and vector[2] < 0.001:
+                if abs(vector[0]) < 0.001 and abs(vector[2]) < 0.001:
                     return None
                 normal = np.cross(vector, [0, -1, 0])
             case "right":
-                if vector[0] < 0.001 and vector[2] < 0.001:
+                if abs(vector[0]) < 0.001 and abs(vector[2]) < 0.001:
                     return None
                 normal = np.cross(vector, [0, 1, 0])
             case "front":
-                if vector[1] < 0.001 and vector[2] < 0.001:
+                if abs(vector[1]) < 0.001 and abs(vector[2]) < 0.001:
                     return None
                 normal = np.cross(vector, [-1, 0, 0])
             case "back":
-                if vector[1] < 0.001 and vector[2] < 0.001:
+                if abs(vector[1]) < 0.001 and abs(vector[2]) < 0.001:
                     return None
                 normal = np.cross(vector, [1, 0, 0])
+            case _:
+                raise ValueError(
+                    "arc_direction {arc_direction} not supported ! Should be one of: 'above', 'below', 'front', 'back', 'right' or 'left'"
+                )
 
         if np.linalg.norm(normal) == 0:
             # Return None if the vector is in the requested arc_direction

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -318,7 +318,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
             return GoToId(id=-1)
 
         if with_cartesian_interpolation:
-            return self._goto_cartesian_interpolation(target, duration, interpolation_frequency, circular_interpolation, arc_direction)
+            return self._goto_cartesian_interpolation(target=target, duration=duration, interpolation_frequency=interpolation_frequency, circular_interpolation=circular_interpolation, arc_direction=arc_direction)
 
         if q0 is not None:
             q0 = list_to_arm_position(q0)

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -504,7 +504,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         vector_origin_center = origin_trans - center
         vector_target_center = target_trans - center
 
-        if radius == 0:
+        if np.isclose(radius, 0, atol=1e-03):
             self._logger.warning(f"{self._part_id.name} is already at the target pose. No command sent.")
             return
         if secondary_radius is None:

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -415,9 +415,9 @@ class Arm(JointsBasedPart, IGoToBasedPart):
             angle2 = np.arctan2(vector2[1], vector2[0])
 
             if arc_direction == 'above':
-            # Passer par le dessus : Assurer que l'angle2 est après l'angle1 dans le sens anti-horaire
-            if angle2 <= angle1:
-                angle2 += 2 * np.pi
+                # Passer par le dessus : Assurer que l'angle2 est après l'angle1 dans le sens anti-horaire
+                if angle2 <= angle1:
+                    angle2 += 2 * np.pi
             elif arc_direction == 'below':
                 # Passer par le dessous : Assurer que l'angle2 est avant l'angle1 dans le sens anti-horaire
                 if angle2 >= angle1:

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -384,6 +384,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         q2, trans2 = decompose_matrix(target)
 
         if not circular_interpolation:
+            print("linear")
             for t in np.linspace(0, 1, nb_steps):
                 # Linear interpolation for translation
                 trans_interpolated = (1 - t) * trans1 + t * trans2
@@ -403,6 +404,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
                 time.sleep(time_step)
         
         else:
+            print("circular")
             center = (trans1 + trans2) / 2
             radius = np.linalg.norm(trans2 - trans1) / 2
 

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -515,25 +515,8 @@ class Arm(JointsBasedPart, IGoToBasedPart):
             theta = t * angle
 
             # Rotation of origin_vector around the circle center in the plan defined by 'normal'
-            rotation_matrix = np.array(
-                [
-                    [
-                        np.cos(theta) + normal[0] ** 2 * (1 - np.cos(theta)),
-                        normal[0] * normal[1] * (1 - np.cos(theta)) - normal[2] * np.sin(theta),
-                        normal[0] * normal[2] * (1 - np.cos(theta)) + normal[1] * np.sin(theta),
-                    ],
-                    [
-                        normal[1] * normal[0] * (1 - np.cos(theta)) + normal[2] * np.sin(theta),
-                        np.cos(theta) + normal[1] ** 2 * (1 - np.cos(theta)),
-                        normal[1] * normal[2] * (1 - np.cos(theta)) - normal[0] * np.sin(theta),
-                    ],
-                    [
-                        normal[2] * normal[0] * (1 - np.cos(theta)) - normal[1] * np.sin(theta),
-                        normal[2] * normal[1] * (1 - np.cos(theta)) + normal[0] * np.sin(theta),
-                        np.cos(theta) + normal[2] ** 2 * (1 - np.cos(theta)),
-                    ],
-                ]
-            )
+            q1 = Quaternion(axis=normal, angle=theta)
+            rotation_matrix = q1.rotation_matrix
 
             # Interpolated point in plan
             trans_interpolated = np.dot(rotation_matrix, vector_origin_center)

--- a/src/reachy2_sdk/utils/utils.py
+++ b/src/reachy2_sdk/utils/utils.py
@@ -6,7 +6,7 @@ This module contains various useful functions especially:
 """
 
 from collections import namedtuple
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 import numpy as np
 import numpy.typing as npt
@@ -250,3 +250,47 @@ def invert_affine_transformation_matrix(matrix: npt.NDArray[np.float64]) -> npt.
     inv_matrix[:3, :3] = matrix[:3, :3].T
     inv_matrix[:3, 3] = -matrix[:3, :3].T @ matrix[:3, 3]
     return inv_matrix
+
+
+def get_normal_vector(vector: npt.NDArray[np.float64], arc_direction: str) -> Optional[npt.NDArray[np.float64]]:
+    """Get a normal vector to the given vector in the desired direction.
+
+    direction can be: 'above', 'below', 'front', 'back', 'right' or 'left'.
+    """
+    match arc_direction:
+        case "above":
+            if abs(vector[0]) < 0.001 and abs(vector[1]) < 0.001:
+                return None
+            normal = np.cross(vector, [0, 0, -1])
+        case "below":
+            if abs(vector[0]) < 0.001 and abs(vector[1]) < 0.001:
+                return None
+            normal = np.cross(vector, [0, 0, 1])
+        case "left":
+            if abs(vector[0]) < 0.001 and abs(vector[2]) < 0.001:
+                return None
+            normal = np.cross(vector, [0, -1, 0])
+        case "right":
+            if abs(vector[0]) < 0.001 and abs(vector[2]) < 0.001:
+                return None
+            normal = np.cross(vector, [0, 1, 0])
+        case "front":
+            if abs(vector[1]) < 0.001 and abs(vector[2]) < 0.001:
+                return None
+            normal = np.cross(vector, [-1, 0, 0])
+        case "back":
+            if abs(vector[1]) < 0.001 and abs(vector[2]) < 0.001:
+                return None
+            normal = np.cross(vector, [1, 0, 0])
+        case _:
+            raise ValueError(
+                f"arc_direction '{arc_direction}' not supported! Should be one of: "
+                "'above', 'below', 'front', 'back', 'right' or 'left'"
+            )
+
+    if np.linalg.norm(normal) == 0:
+        # Return None if the vector is in the requested arc_direction
+        return None
+
+    normal = normal / np.linalg.norm(normal)
+    return normal

--- a/tests/units/offline/test_utils.py
+++ b/tests/units/offline/test_utils.py
@@ -10,6 +10,7 @@ from reachy2_sdk.utils.utils import (
     ext_euler_angles_to_list,
     get_grpc_interpolation_mode,
     get_interpolation_mode,
+    get_normal_vector,
     get_pose_matrix,
     invert_affine_transformation_matrix,
     list_to_arm_position,
@@ -261,3 +262,53 @@ def test_invert_affine_transformation_matrix() -> None:
 
     M_computed = invert_affine_transformation_matrix(M)
     assert np.array_equal(M_inv_ref, M_computed)
+
+
+@pytest.mark.offline
+def test_get_normal_vector() -> None:
+    initial_vector = [0, 0.7071, 0.7071]
+    normal_above = get_normal_vector(vector=initial_vector, arc_direction="above")
+    normal_below = get_normal_vector(vector=initial_vector, arc_direction="below")
+    normal_front = get_normal_vector(vector=initial_vector, arc_direction="front")
+    normal_back = get_normal_vector(vector=initial_vector, arc_direction="back")
+    normal_right = get_normal_vector(vector=initial_vector, arc_direction="right")
+    normal_left = get_normal_vector(vector=initial_vector, arc_direction="left")
+
+    expected_normal_above = [-1, 0, 0]
+    expected_normal_below = [1, 0, 0]
+    expected_normal_front = [0, -0.7071, 0.7071]
+    expected_normal_back = [0, 0.7071, -0.7071]
+    expected_normal_right = [-1, 0, 0]
+    expected_normal_left = [1, 0, 0]
+
+    assert np.allclose(normal_above, expected_normal_above, atol=1e-03)
+    assert np.allclose(normal_below, expected_normal_below, atol=1e-03)
+    assert np.allclose(normal_front, expected_normal_front, atol=1e-03)
+    assert np.allclose(normal_back, expected_normal_back, atol=1e-03)
+    assert np.allclose(normal_right, expected_normal_right, atol=1e-03)
+    assert np.allclose(normal_left, expected_normal_left, atol=1e-03)
+
+    initial_vector = [1, 0, 0]
+    normal_above = get_normal_vector(vector=initial_vector, arc_direction="above")
+    normal_below = get_normal_vector(vector=initial_vector, arc_direction="below")
+    normal_front = get_normal_vector(vector=initial_vector, arc_direction="front")
+    normal_back = get_normal_vector(vector=initial_vector, arc_direction="back")
+    normal_right = get_normal_vector(vector=initial_vector, arc_direction="right")
+    normal_left = get_normal_vector(vector=initial_vector, arc_direction="left")
+
+    expected_normal_above = [0, 1, 0]
+    expected_normal_below = [0, -1, 0]
+    expected_normal_front = None
+    expected_normal_back = None
+    expected_normal_right = [0, 0, 1]
+    expected_normal_left = [0, 0, -1]
+
+    assert np.allclose(normal_above, expected_normal_above, atol=1e-03)
+    assert np.allclose(normal_below, expected_normal_below, atol=1e-03)
+    assert np.allclose(normal_right, expected_normal_right, atol=1e-03)
+    assert np.allclose(normal_left, expected_normal_left, atol=1e-03)
+    assert normal_front is expected_normal_front
+    assert normal_back is expected_normal_back
+
+    with pytest.raises(ValueError):
+        get_normal_vector([0.1, 0.2, 0.3], arc_direction="coucou")

--- a/tests/units/online/test_interpolations.py
+++ b/tests/units/online/test_interpolations.py
@@ -199,3 +199,31 @@ def test_send_cartesian_interpolation_circular(reachy_sdk_zeroed: ReachySDK) -> 
         assert np.isclose(pose[2, 3], zB, 1e-03)
         assert np.allclose(pose[:3, :3], B_forward[:3, :3], atol=1e-03)
     assert went_back
+
+    # Test right
+    inter_poses = test_pose_trajectory(A, B, 3.0, arc_direction="right")
+    B_forward = reachy_sdk_zeroed.r_arm.forward_kinematics()
+    assert np.allclose(B_forward, B, atol=1e-03)
+    for pose in inter_poses:
+        assert np.isclose(pose[0, 3], xB, 1e-03)
+        assert (pose[1, 3] <= max(yA, yB) or np.isclose(pose[1, 3], max(yA, yB), 1e-03)) and (
+            pose[1, 3] >= min(yA, yB) or np.isclose(pose[1, 3], min(yA, yB), 1e-03)
+        )
+        assert (pose[2, 3] <= max(zA, zB) or np.isclose(pose[2, 3], max(zA, zB), 1e-03)) and (
+            pose[2, 3] >= min(zA, zB) or np.isclose(pose[2, 3], max(zA, zB), 1e-03)
+        )
+        assert np.allclose(pose[:3, :3], B_forward[:3, :3], atol=1e-03)
+
+    # Test left
+    inter_poses = test_pose_trajectory(A, B, 3.0, arc_direction="left")
+    B_forward = reachy_sdk_zeroed.r_arm.forward_kinematics()
+    assert np.allclose(B_forward, B, atol=1e-03)
+    for pose in inter_poses:
+        assert np.isclose(pose[0, 3], xB, 1e-03)
+        assert (pose[1, 3] <= max(yA, yB) or np.isclose(pose[1, 3], max(yA, yB), 1e-03)) and (
+            pose[1, 3] >= min(yA, yB) or np.isclose(pose[1, 3], min(yA, yB), 1e-03)
+        )
+        assert (pose[2, 3] <= max(zA, zB) or np.isclose(pose[2, 3], max(zA, zB), 1e-03)) and (
+            pose[2, 3] >= min(zA, zB) or np.isclose(pose[2, 3], max(zA, zB), 1e-03)
+        )
+        assert np.allclose(pose[:3, :3], B_forward[:3, :3], atol=1e-03)

--- a/tests/units/online/test_interpolations.py
+++ b/tests/units/online/test_interpolations.py
@@ -107,9 +107,7 @@ def test_send_cartesian_interpolation_circular(reachy_sdk_zeroed: ReachySDK) -> 
         t = LoopThread(reachy_sdk_zeroed, "r_arm")
         t.start()
         tic = time.time()
-        reachy_sdk_zeroed.r_arm.send_cartesian_interpolation(
-            B, duration=duration, circular_interpolation=True, arc_direction=arc_direction
-        )
+        reachy_sdk_zeroed.r_arm.send_cartesian_interpolation(B, duration=duration, arc_direction=arc_direction)
         elapsed_time = time.time() - tic
         t.stop()
         assert np.isclose(elapsed_time, duration, 1)

--- a/tests/units/online/test_interpolations.py
+++ b/tests/units/online/test_interpolations.py
@@ -1,0 +1,63 @@
+import time
+from threading import Thread
+
+import numpy as np
+import pytest
+
+from reachy2_sdk.reachy_sdk import ReachySDK
+
+from .test_basic_movements import build_pose_matrix
+
+
+class LoopThread:
+    def __init__(self, reachy: ReachySDK, arm: str):
+        self.reachy = reachy
+        self.arm = arm
+        self.running = False
+        self.forward_list = []
+        self.thread = Thread(
+            target=self.loop_forward_function,
+            args=(
+                self.reachy,
+                self.arm,
+            ),
+        )
+
+    def start(self):
+        self.running = True
+        self.thread.start()
+
+    def stop(self):
+        self.running = False
+        self.thread.join()
+
+    def loop_forward_function(self, reachy: ReachySDK, arm: str):
+        while self.running:
+            if arm == "right":
+                self.forward_list.append(reachy.r_arm.forward_kinematics())
+            else:
+                self.forward_list.append(reachy.l_arm.forward_kinematics())
+            time.sleep(0.5)
+
+
+@pytest.mark.online
+def test_send_cartesian_interpolation(reachy_sdk_zeroed: ReachySDK) -> None:
+    A = build_pose_matrix(0.3, -0.2, -0.3)
+    reachy_sdk_zeroed.r_arm.goto_from_matrix(A, wait=True)
+    B = build_pose_matrix(0.3, -0.4, -0.3)
+    t = LoopThread(reachy_sdk_zeroed, "r_arm")
+    t.start()
+    tic = time.time()
+    reachy_sdk_zeroed.r_arm.send_cartesian_interpolation(B, duration=3.0)
+    elapsed_time = time.time() - tic
+    t.stop()
+    assert np.isclose(elapsed_time, 3.0, 1)
+
+    B_forward = reachy_sdk_zeroed.r_arm.forward_kinematics()
+    print(t.forward_list)
+    assert np.allclose(B_forward, B, atol=1e-03)
+
+    for pose in t.forward_list:
+        assert np.isclose(pose[0, 3], 0.3, 1e-03)
+        assert np.isclose(pose[2, 3], -0.3, 1e-03)
+        assert pose[1, 3] <= -0.2 and pose[1, 3] >= -0.4

--- a/tests/units/online/test_interpolations.py
+++ b/tests/units/online/test_interpolations.py
@@ -107,7 +107,9 @@ def test_send_cartesian_interpolation_circular(reachy_sdk_zeroed: ReachySDK) -> 
         t = LoopThread(reachy_sdk_zeroed, "r_arm")
         t.start()
         tic = time.time()
-        reachy_sdk_zeroed.r_arm.send_cartesian_interpolation(B, duration=duration, arc_direction=arc_direction)
+        reachy_sdk_zeroed.r_arm.send_cartesian_interpolation(
+            B, duration=duration, arc_direction=arc_direction, precision_distance_xyz=0.005
+        )
         elapsed_time = time.time() - tic
         t.stop()
         assert np.isclose(elapsed_time, duration, 1)


### PR DESCRIPTION
This one is not ready for merge, but I would like some inputs.

The idea: we can do linear or elliptic interpolation in cartesian space, so that the trajectory of the end effector is known, unlike with goto_joints or goto_from_matrix (interpolations are in joint space for both).

We can call `reachy.r_arm.send_cartesian_interpolation(target_pose, duration)` to do so, with by default a linear interpolation.

Using `reachy.r_arm.send_cartesian_interpolation(target_pose, duration, circular_interpolation=True, arc_direction='below')` makes a circular interpolation and chooses the arc in -z direction normal to the vector current/target pose. *arc_direction* can be : `below`, `above`, `right`, `left`, `front` or `back`. (if the arc has no solution, does linear interpolation instead)

Last option is the *secondary_radius*, which makes possible elliptic interpolation, deciding how far the end effector is going from the linear interpolation. Can be customized with: `reachy.r_arm.send_cartesian_interpolation(target_pose, duration, circular_interpolation, arc_direction='below', secondary_radius=0.05)`

Also tests are quite difficult to read and write ....