### PR TITLE
Modify speeds on turn_on

### DIFF
--- a/src/reachy2_sdk/parts/hand.py
+++ b/src/reachy2_sdk/parts/hand.py
@@ -59,6 +59,9 @@ class Hand(Part):
 
         self._outgoing_goal_positions: Optional[float] = None
 
+    def _set_speed_limits(self, value: int) -> None:
+        return super()._set_speed_limits(value)
+
     @property
     def opening(self) -> float:
         """Return the opening of the hand in percentage."""

--- a/src/reachy2_sdk/parts/joints_based_part.py
+++ b/src/reachy2_sdk/parts/joints_based_part.py
@@ -70,3 +70,6 @@ class JointsBasedPart(Part):
             limit=value,
         )
         self._stub.SetSpeedLimit(req)
+
+    def _set_speed_limits(self, value: int) -> None:
+        return self.set_speed_limits(value)

--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -289,3 +289,6 @@ class MobileBase(Part):
 
     def _update_audit_status(self, new_status: MobileBaseStatus) -> None:
         pass
+
+    def _set_speed_limits(self, value: int) -> None:
+        return super()._set_speed_limits(value)

--- a/src/reachy2_sdk/parts/part.py
+++ b/src/reachy2_sdk/parts/part.py
@@ -40,8 +40,12 @@ class Part(ABC):
         self._actuators: Dict[str, Any] = {}
 
     def turn_on(self) -> None:
+        self._set_speed_limits(1)
+        time.sleep(0.05)
         self._turn_on()
-        time.sleep(0.5)
+        time.sleep(0.05)
+        self._set_speed_limits(100)
+        time.sleep(0.4)
 
     def turn_off(self) -> None:
         self._turn_off()
@@ -71,6 +75,10 @@ class Part(ABC):
 
     @abstractmethod
     def _update_audit_status(self, state: ArmStatus | HeadStatus | HandStatus | MobileBaseStatus) -> None:
+        pass
+
+    @abstractmethod
+    def _set_speed_limits(self, value: int) -> None:
         pass
 
     @property

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -427,10 +427,16 @@ class ReachySDK:
             self._logger.warning("Cannot turn on Reachy, not connected.")
             return False
         for part in self.info._enabled_parts.values():
+            part.set_speed_limits(1)
+        time.sleep(0.05)
+        for part in self.info._enabled_parts.values():
             part._turn_on()
         if self._mobile_base is not None:
             self._mobile_base._turn_on()
-        time.sleep(0.5)
+        time.sleep(0.05)
+        for part in self.info._enabled_parts.values():
+            part.set_speed_limits(100)
+        time.sleep(0.4)
 
         return True
 


### PR DESCRIPTION
Using `reachy.turn_on()` should be smoother than before, as we reduce speed limits to 1% before turning on.