### PR TITLE
397 expose cameras extrinsic matrix

### DIFF
--- a/src/examples/cameras.py
+++ b/src/examples/cameras.py
@@ -11,7 +11,8 @@ def display_teleop_cam() -> None:
     if reachy.cameras.teleop is None:
         exit("There is no teleop camera.")
 
-    print(f"Left camara parameters {reachy.cameras.teleop.get_parameters(CameraView.LEFT)}")
+    print(f"Left camera parameters {reachy.cameras.teleop.get_parameters(CameraView.LEFT)}")
+    print(f"Left camera extrinsic parameters {reachy.cameras.teleop.get_extrinsics(CameraView.LEFT)}")
     # print(reachy.cameras.teleop.get_parameters(CameraView.RIGHT))
 
     try:
@@ -30,6 +31,9 @@ def display_teleop_cam() -> None:
 def display_depth_cam() -> None:
     if reachy.cameras.depth is None:
         exit("There is no depth camera.")
+
+    print(f"Depth camera parameters {reachy.cameras.depth.get_parameters()}")
+    print(f"Depth camera extrinsic parameters {reachy.cameras.depth.get_extrinsics()}")
 
     try:
         while True:

--- a/src/reachy2_sdk/media/camera.py
+++ b/src/reachy2_sdk/media/camera.py
@@ -53,6 +53,8 @@ class Camera:
     ) -> Optional[
         Tuple[int, int, str, npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64], npt.NDArray[np.float64]]
     ]:
+        """Returns the height, width, distortion model, distortion coefficients, instrinsic matrix,"""
+        """ rotation matrix and projection matrix"""
         params = self._video_stub.GetParameters(request=ViewRequest(camera_feat=self._cam_info, view=view.value))
         if params.K == []:
             self._logger.warning("No parameter retrieved")
@@ -66,6 +68,7 @@ class Camera:
         return params.height, params.width, params.distortion_model, D, K, R, P
 
     def get_extrinsics(self, view: CameraView = CameraView.LEFT) -> Optional[npt.NDArray[np.float64]]:
+        """Returns the 4x4 extrinsic matrix"""
         res = self._video_stub.GetExtrinsics(request=ViewRequest(camera_feat=self._cam_info, view=view.value))
         if res.extrinsics is None:
             self._logger.warning("No extrinsic matrix retrieved")

--- a/src/reachy2_sdk/utils/utils.py
+++ b/src/reachy2_sdk/utils/utils.py
@@ -165,3 +165,16 @@ def matrix_from_euler_angles(roll: float, pitch: float, yaw: float, degrees: boo
 
     rotation_matrix = R_z @ R_y @ R_x
     return rotation_matrix
+
+
+def invert_affine_transformation_matrix(matrix: npt.NDArray[np.float64]) -> npt.NDArray[np.float64]:
+    """Invert an homegeneous transformation matrix"""
+    """with matrix M = [R t] , returns M^-1 = [R.T -R.T * t]"""
+    """                [0 1]                  [0          1]"""
+    if matrix.shape != (4, 4):
+        raise ValueError("matrix should be 4x4")
+
+    inv_matrix = np.eye(4)
+    inv_matrix[:3, :3] = matrix[:3, :3].T
+    inv_matrix[:3, 3] = -matrix[:3, :3].T @ matrix[:3, 3]
+    return inv_matrix


### PR DESCRIPTION
Requires these two repos:
https://github.com/pollen-robotics/reachy2-sdk-api/pull/144
https://github.com/pollen-robotics/reachy2_sdk_server/pull/174

@ClaireHzl can you test if it actually works by modifying your example (https://github.com/pollen-robotics/demo_month/blob/demo_fruits/notebook_fruits.ipynb)

```
T_cam_world = reachy.cameras.depth.get_extrinsics()
T_world_cam = invert_affine_transformation_matrix(T_cam_world)
```