### PR TITLE
407 send goal position doesnt not do anything when position is not reachable

### DIFF
--- a/src/reachy2_sdk/orbita/orbita2d.py
+++ b/src/reachy2_sdk/orbita/orbita2d.py
@@ -1,4 +1,5 @@
 """This module defines the Orbita2d class and its registers, joints, motors and axis."""
+from threading import Thread
 from typing import Any, Dict, List
 
 from google.protobuf.wrappers_pb2 import FloatValue
@@ -147,6 +148,9 @@ class Orbita2d(Orbita):
             )
             self._outgoing_goal_positions = {}
             self._stub.SendCommand(command)
+            if not self._thread_check_position.is_alive():
+                self._thread_check_position = Thread(target=self._check_goal_positions, daemon=True)
+                self._thread_check_position.start()
 
     def set_speed_limits(self, speed_limit: float | int) -> None:
         """Set a speed_limit as a percentage of the max speed on all motors of the actuator"""

--- a/src/reachy2_sdk/orbita/orbita2d.py
+++ b/src/reachy2_sdk/orbita/orbita2d.py
@@ -1,5 +1,4 @@
 """This module defines the Orbita2d class and its registers, joints, motors and axis."""
-from threading import Thread
 from typing import Any, Dict, List
 
 from google.protobuf.wrappers_pb2 import FloatValue
@@ -148,9 +147,7 @@ class Orbita2d(Orbita):
             )
             self._outgoing_goal_positions = {}
             self._stub.SendCommand(command)
-            if not self._thread_check_position.is_alive():
-                self._thread_check_position = Thread(target=self._check_goal_positions, daemon=True)
-                self._thread_check_position.start()
+            self._post_send_goal_positions()
 
     def set_speed_limits(self, speed_limit: float | int) -> None:
         """Set a speed_limit as a percentage of the max speed on all motors of the actuator"""

--- a/src/reachy2_sdk/orbita/orbita3d.py
+++ b/src/reachy2_sdk/orbita/orbita3d.py
@@ -1,4 +1,6 @@
 """This module defines the Orbita3d class and its registers, joints, motors and axis."""
+
+from threading import Thread
 from typing import Dict, List
 
 from google.protobuf.wrappers_pb2 import FloatValue
@@ -139,6 +141,9 @@ class Orbita3d(Orbita):
             )
             self._outgoing_goal_positions = {}
             self._stub.SendCommand(command)
+            if not self._thread_check_position.is_alive():
+                self._thread_check_position = Thread(target=self._check_goal_positions, daemon=True)
+                self._thread_check_position.start()
 
     def set_speed_limits(self, speed_limit: float | int) -> None:
         """Set a speed_limit as a percentage of the max speed on all motors of the actuator"""

--- a/src/reachy2_sdk/orbita/orbita3d.py
+++ b/src/reachy2_sdk/orbita/orbita3d.py
@@ -1,6 +1,5 @@
 """This module defines the Orbita3d class and its registers, joints, motors and axis."""
 
-from threading import Thread
 from typing import Dict, List
 
 from google.protobuf.wrappers_pb2 import FloatValue
@@ -141,9 +140,7 @@ class Orbita3d(Orbita):
             )
             self._outgoing_goal_positions = {}
             self._stub.SendCommand(command)
-            if not self._thread_check_position.is_alive():
-                self._thread_check_position = Thread(target=self._check_goal_positions, daemon=True)
-                self._thread_check_position.start()
+            self._post_send_goal_positions()
 
     def set_speed_limits(self, speed_limit: float | int) -> None:
         """Set a speed_limit as a percentage of the max speed on all motors of the actuator"""


### PR DESCRIPTION

Something like this print a warning:
```
reachy.head.neck.roll.goal_position = 30 #20 is ok
reachy.send_goal_positions()
```
or 

```
reachy.r_arm.elbow.pitch.goal_position = -90
reachy.send_goal_positions()
```