### PR TITLE
399 robot is stuck in infinite loop using translate by with wait=true

### DIFF
--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -368,7 +368,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         response = self._goto_stub.GoToCartesian(request)
         if response.id == -1:
             self._logger.error(f"Target pose:\n {target} \nwas not reachable. No command sent.")
-        if wait:
+        elif wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):
                 time.sleep(0.1)
@@ -591,7 +591,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         response = self._goto_stub.GoToJoints(request)
         if response.id == -1:
             self._logger.error(f"Position {positions} was not reachable. No command sent.")
-        if wait:
+        elif wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):
                 time.sleep(0.1)
@@ -763,6 +763,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
             interpolation_mode=get_grpc_interpolation_mode(interpolation_mode),
         )
         response = self._goto_stub.GoToJoints(request)
+
         if wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -369,7 +369,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Target pose:\n {target} \nwas not reachable. No command sent.")
         elif wait:
-            self._wait_goto(response, duration + 1)
+            self._wait_goto(response)
         return response
 
     def send_cartesian_interpolation(
@@ -589,7 +589,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {positions} was not reachable. No command sent.")
         elif wait:
-            self._wait_goto(response, duration + 1)
+            self._wait_goto(response)
         return response
 
     def get_translation_by(
@@ -761,7 +761,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {goal_position} was not reachable. No command sent.")
         elif wait:
-            self._wait_goto(response, duration + 1)
+            self._wait_goto(response)
         return response
 
     def get_joints_positions(self, degrees: bool = True, round: Optional[int] = None) -> List[float]:

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -369,10 +369,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Target pose:\n {target} \nwas not reachable. No command sent.")
         elif wait:
-            self._logger.info(f"Waiting for movement with {response}.")
-            while not self._is_goto_finished(response):
-                time.sleep(0.1)
-            self._logger.info(f"Movement with {response} finished.")
+            self._wait_goto(response, duration + 1)
         return response
 
     def send_cartesian_interpolation(
@@ -592,10 +589,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {positions} was not reachable. No command sent.")
         elif wait:
-            self._logger.info(f"Waiting for movement with {response}.")
-            while not self._is_goto_finished(response):
-                time.sleep(0.1)
-            self._logger.info(f"Movement with {response} finished.")
+            self._wait_goto(response, duration + 1)
         return response
 
     def get_translation_by(
@@ -767,10 +761,7 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {goal_position} was not reachable. No command sent.")
         elif wait:
-            self._logger.info(f"Waiting for movement with {response}.")
-            while not self._is_goto_finished(response):
-                time.sleep(0.1)
-            self._logger.info(f"Movement with {response} finished.")
+            self._wait_goto(response, duration + 1)
         return response
 
     def get_joints_positions(self, degrees: bool = True, round: Optional[int] = None) -> List[float]:

--- a/src/reachy2_sdk/parts/arm.py
+++ b/src/reachy2_sdk/parts/arm.py
@@ -764,7 +764,9 @@ class Arm(JointsBasedPart, IGoToBasedPart):
         )
         response = self._goto_stub.GoToJoints(request)
 
-        if wait:
+        if response.id == -1:
+            self._logger.error(f"Position {goal_position} was not reachable. No command sent.")
+        elif wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):
                 time.sleep(0.1)

--- a/src/reachy2_sdk/parts/goto_based_part.py
+++ b/src/reachy2_sdk/parts/goto_based_part.py
@@ -1,3 +1,5 @@
+import logging
+import time
 from abc import ABC
 from typing import List, Optional
 
@@ -27,6 +29,7 @@ class IGoToBasedPart(ABC):
         """Initialize the common attributes."""
         self.part = part
         self._goto_stub = goto_stub
+        self._logger_goto = logging.getLogger(__name__)  # avoid name conflict with class logger
 
     def get_goto_playing(self) -> GoToId:
         """Return the id of the goto currently playing on the part"""
@@ -80,3 +83,14 @@ class IGoToBasedPart(ABC):
             or state.goal_status == GoalStatus.STATUS_SUCCEEDED
         )
         return result
+
+    def _wait_goto(self, id: GoToId, timeout: float = 10) -> None:
+        """Wait for a goto to finish. timeout is in seconds."""
+        self._logger_goto.info(f"Waiting for movement with {id}.")
+        t1 = time.time()
+        while not self._is_goto_finished(id):
+            time.sleep(0.1)
+            if time.time() - t1 > timeout:
+                self._logger_goto.warning(f"Waiting time for movement with {id} is timeout.")
+                return
+        self._logger_goto.info(f"Movement with {id} finished.")

--- a/src/reachy2_sdk/parts/goto_based_part.py
+++ b/src/reachy2_sdk/parts/goto_based_part.py
@@ -29,7 +29,7 @@ class IGoToBasedPart(ABC):
         """Initialize the common attributes."""
         self.part = part
         self._goto_stub = goto_stub
-        self._logger_goto = logging.getLogger(__name__)  # avoid name conflict with class logger
+        self._logger_goto = logging.getLogger(__name__)  # not using self._logger to avoid name conflict in multiple inheritance
 
     def get_goto_playing(self) -> GoToId:
         """Return the id of the goto currently playing on the part"""

--- a/src/reachy2_sdk/parts/head.py
+++ b/src/reachy2_sdk/parts/head.py
@@ -133,7 +133,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {x}, {y}, {z} was not reachable. No command sent.")
         elif wait:
-            self._wait_goto(response, duration + 1)
+            self._wait_goto(response)
         return response
 
     def goto_joints(
@@ -178,7 +178,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {positions} was not reachable. No command sent.")
         elif wait:
-            self._wait_goto(response, duration + 1)
+            self._wait_goto(response)
         return response
 
     def _goto_single_joint(
@@ -207,7 +207,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {goal_position} was not reachable. No command sent.")
         elif wait:
-            self._wait_goto(response, duration + 1)
+            self._wait_goto(response)
         return response
 
     def goto_quat(
@@ -234,7 +234,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Orientation {q} was not reachable. No command sent.")
         elif wait:
-            self._wait_goto(response, duration + 1)
+            self._wait_goto(response)
         return response
 
     def send_goal_positions(self) -> None:

--- a/src/reachy2_sdk/parts/head.py
+++ b/src/reachy2_sdk/parts/head.py
@@ -5,7 +5,6 @@ Handles all specific method to an Head:
 - look_at function
 """
 
-import time
 from typing import List
 
 import grpc
@@ -134,10 +133,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {x}, {y}, {z} was not reachable. No command sent.")
         elif wait:
-            self._logger.info(f"Waiting for movement with {response}.")
-            while not self._is_goto_finished(response):
-                time.sleep(0.1)
-            self._logger.info(f"Movement with {response} finished.")
+            self._wait_goto(response, duration + 1)
         return response
 
     def goto_joints(
@@ -182,10 +178,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {positions} was not reachable. No command sent.")
         elif wait:
-            self._logger.info(f"Waiting for movement with {response}.")
-            while not self._is_goto_finished(response):
-                time.sleep(0.1)
-            self._logger.info(f"Movement with {response} finished.")
+            self._wait_goto(response, duration + 1)
         return response
 
     def _goto_single_joint(
@@ -214,10 +207,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Position {goal_position} was not reachable. No command sent.")
         elif wait:
-            self._logger.info(f"Waiting for movement with {response}.")
-            while not self._is_goto_finished(response):
-                time.sleep(0.1)
-            self._logger.info(f"Movement with {response} finished.")
+            self._wait_goto(response, duration + 1)
         return response
 
     def goto_quat(
@@ -244,10 +234,7 @@ class Head(JointsBasedPart, IGoToBasedPart):
         if response.id == -1:
             self._logger.error(f"Orientation {q} was not reachable. No command sent.")
         elif wait:
-            self._logger.info(f"Waiting for movement with {response}.")
-            while not self._is_goto_finished(response):
-                time.sleep(0.1)
-            self._logger.info(f"Movement with {response} finished.")
+            self._wait_goto(response, duration + 1)
         return response
 
     def send_goal_positions(self) -> None:

--- a/src/reachy2_sdk/parts/head.py
+++ b/src/reachy2_sdk/parts/head.py
@@ -131,7 +131,9 @@ class Head(JointsBasedPart, IGoToBasedPart):
             interpolation_mode=get_grpc_interpolation_mode(interpolation_mode),
         )
         response = self._goto_stub.GoToCartesian(request)
-        if wait:
+        if response.id == -1:
+            self._logger.error(f"Position {x}, {y}, {z} was not reachable. No command sent.")
+        elif wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):
                 time.sleep(0.1)
@@ -177,7 +179,9 @@ class Head(JointsBasedPart, IGoToBasedPart):
             interpolation_mode=get_grpc_interpolation_mode(interpolation_mode),
         )
         response = self._goto_stub.GoToJoints(request)
-        if wait:
+        if response.id == -1:
+            self._logger.error(f"Position {positions} was not reachable. No command sent.")
+        elif wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):
                 time.sleep(0.1)
@@ -207,7 +211,9 @@ class Head(JointsBasedPart, IGoToBasedPart):
             interpolation_mode=get_grpc_interpolation_mode(interpolation_mode),
         )
         response = self._goto_stub.GoToJoints(request)
-        if wait:
+        if response.id == -1:
+            self._logger.error(f"Position {goal_position} was not reachable. No command sent.")
+        elif wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):
                 time.sleep(0.1)
@@ -235,7 +241,9 @@ class Head(JointsBasedPart, IGoToBasedPart):
             interpolation_mode=get_grpc_interpolation_mode(interpolation_mode),
         )
         response = self._goto_stub.GoToJoints(request)
-        if wait:
+        if response.id == -1:
+            self._logger.error(f"Orientation {q} was not reachable. No command sent.")
+        elif wait:
             self._logger.info(f"Waiting for movement with {response}.")
             while not self._is_goto_finished(response):
                 time.sleep(0.1)

--- a/tests/units/online/test_advanced_goto_functions.py
+++ b/tests/units/online/test_advanced_goto_functions.py
@@ -483,6 +483,12 @@ def test_wait_move(reachy_sdk_zeroed: ReachySDK) -> None:
     elapsed_time = time.time() - tic
     assert elapsed_time < 0.1
 
+    tic = time.time()
+    reachy_sdk_zeroed.goto_posture("default", duration=1.0)
+    reachy_sdk_zeroed.r_arm.goto_from_matrix(A, wait=True, duration=1.0)
+    elapsed_time = time.time() - tic
+    assert elapsed_time >= 2.0
+
 
 @pytest.mark.online
 def test_is_goto_finished(reachy_sdk_zeroed: ReachySDK) -> None:


### PR DESCRIPTION
The bug was due to the `if wait` that was not supposed to be triggered with unreachable comment (i.e. there is nothing to wait for). It is fixed by a `elif`

```
    response = self._goto_stub.GoToCartesian(request)
    if response.id == -1:
        self._logger.error(f"Target pose:\\n {target} \\nwas not reachable. No command sent.")
    if wait:
        self._logger.info(f"Waiting for movement with {response}.")
        while not self._is_goto_finished(response):
            time.sleep(0.1)
        self._logger.info(f"Movement with {response} finished.")
    return response
```

I've added this mechanism to all goto functions, even if the goto_joints don't raise unreachable errors for now. 
Also there is a timeout in the wait function to be sure that we don't wait forever if something goes bad on the server side (timeout is set to duration + 1 sec.)
\+ little bit of refactoring