### PR TITLE
Safer turn off smoothly

### DIFF
--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -529,7 +529,8 @@ class ReachySDK:
             self._logger.warning("Cannot turn off Reachy, not connected.")
             return False
         speed_limit_high = 25
-        torque_limit_low = 35
+        # Enough to sustain the arm weight
+        torque_limit_low = 50
         torque_limit_high = 100
         duration = 3
         arms_list = []
@@ -548,7 +549,7 @@ class ReachySDK:
         countingTime = 0
         while countingTime < duration:
             time.sleep(1)
-            torque_limit_low -= 10
+            torque_limit_low -= 15
             for arm_part in arms_list:
                 arm_part.set_torque_limits(torque_limit_low)
             countingTime += 1


### PR DESCRIPTION
Simple change to increase the initial torque used during the first motion of the turn_off_smoothly. This is to avoid the case where the turn_off_smoothly is started when the arms are high : 35% of the max torque was not enough to sustain gravity and a collision with the tripod happens.

Tested on the physical robot.

We also tested with Claire a turn_off_smoothly on top of a table and the arms do not have enough force (at all) in this configuration to make the robot fall.
