### PR TITLE
update goto_posture parameters for head

### DIFF
--- a/src/reachy2_sdk/parts/goto_based_part.py
+++ b/src/reachy2_sdk/parts/goto_based_part.py
@@ -155,3 +155,15 @@ class IGoToBasedPart(ABC):
     def _check_goto_parameters(self, duration: float, target: Any, q0: Optional[List[float]] = None) -> None:
         """Check the validity of the parameters for a goto movement."""
         pass
+
+    @abstractmethod
+    def goto_posture(
+        self,
+        common_posture: str = "default",
+        duration: float = 2,
+        wait: bool = False,
+        wait_for_goto_end: bool = True,
+        interpolation_mode: str = "minimum_jerk",
+    ) -> GoToId:
+        """Send all joints to standard positions with optional parameters for duration, waiting, and interpolation mode."""
+        pass

--- a/src/reachy2_sdk/parts/head.py
+++ b/src/reachy2_sdk/parts/head.py
@@ -405,8 +405,8 @@ class Head(JointsBasedPart, IGoToBasedPart):
 
     def goto_posture(
         self,
-        duration: float = 2,
         common_posture: str = "default",
+        duration: float = 2,
         wait: bool = False,
         wait_for_goto_end: bool = True,
         interpolation_mode: str = "minimum_jerk",

--- a/src/reachy2_sdk/parts/head.py
+++ b/src/reachy2_sdk/parts/head.py
@@ -416,6 +416,8 @@ class Head(JointsBasedPart, IGoToBasedPart):
         The default posture sets the neck joints to [0, -10, 0] (roll, pitch, yaw).
 
         Args:
+            common_posture: The standard positions to which all joints will be sent.
+                It can be 'default' or 'elbow_90'. Defaults to 'default'.
             duration: The time in seconds for the neck to reach the target posture. Defaults to 2.
             wait: Whether to wait for the movement to complete before returning. Defaults to False.
             wait_for_goto_end: Whether to wait for all previous goto commands to finish before executing

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -609,23 +609,23 @@ class ReachySDK:
     def goto_posture(
         self,
         common_posture: str = "default",
+        duration: float = 2,
         wait: bool = False,
         wait_for_goto_end: bool = True,
-        duration: float = 2,
         interpolation_mode: str = "minimum_jerk",
     ) -> GoToHomeId:
         """Move the robot to a predefined posture.
 
         Args:
             common_posture: The name of the posture. It can be 'default' or 'elbow_90'. Defaults to 'default'.
+            duration: The time duration in seconds for the robot to move to the specified posture.
+                Defaults to 2.
             wait: Determines whether the program should wait for the movement to finish before
                 returning. If set to `True`, the program waits for the movement to complete before continuing
                 execution. Defaults to `False`.
             wait_for_goto_end: Specifies whether commands will be sent to a part immediately or
                 only after all previous commands in the queue have been executed. If set to `False`, the program
                 will cancel all executing moves and queues. Defaults to `True`.
-            duration: The time duration in seconds for the robot to move to the specified posture.
-                Defaults to 2.
             interpolation_mode: The type of interpolation used when moving the arm's joints.
                 Can be 'minimum_jerk' or 'linear'. Defaults to 'minimum_jerk'.
 


### PR DESCRIPTION
The parameters of the head goto_posture were not in the same order as the other parts, so a reachy.head.goto_posture("default") raised an error. 