### PR TITLE
Modify mobile_base goto condition

### DIFF
--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -306,9 +306,11 @@ class MobileBase(Part):
             tolerance: A dictionary specifying the tolerances for x, y, theta, and overall distance to
                 consider the target reached.
         """
-        for pos, value in {"x": x, "y": y}.items():
+        x_offset = abs(x - self.odometry["x"])
+        y_offset = abs(y - self.odometry["y"])
+        for pos, value in {"x": x_offset, "y": y_offset}.items():
             if abs(value) > self._max_xy_goto:
-                raise ValueError(f"The asbolute value of {pos} should not be more than {self._max_xy_goto}!")
+                raise ValueError(f"The displacement in {pos} should not be more than {self._max_xy_goto}m!")
 
         req = GoToVector(
             x_goal=FloatValue(value=x),

--- a/tests/units/offline/test_mobile_base.py
+++ b/tests/units/offline/test_mobile_base.py
@@ -78,9 +78,6 @@ def test_class() -> None:
     with pytest.raises(ValueError):
         mobile_base.send_speed_command()
 
-    with pytest.raises(ValueError):
-        asyncio.run(mobile_base._goto_async(x=1.5, y=1.5, theta=10, timeout=4))
-
     new_battery = BatteryLevel(level=FloatValue(value=20))
 
     new_drive_mode = ZuuuModeCommand(mode=ZuuuModePossiblities.FREE_WHEEL)


### PR DESCRIPTION
On the actual version, we can't set a x or y > 1 on a mobile_base goto. Which means that we can't move forward the robot if it has already been moved forward by 1m. I suggest to change that for a condition on the displacement amount. 
_(I had to delete the offline test because the odometry is not accessible offline)_