### PR TITLE
382 stuck in turn on

### DIFF
--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -517,12 +517,10 @@ class ReachySDK:
             return False
 
         speed_limit_high = 25
-        success = self.is_on() and (
-            (not self._l_arm or not self._l_arm.gripper or self._l_arm.gripper.is_on())
-            and (not self._r_arm or not self._r_arm.gripper or self._r_arm.gripper.is_on())
-        )
+        max_iterations = 10
+        ite = 0
 
-        while not success:
+        while not self._is_fully_on() and ite < max_iterations:
             for part in self.info._enabled_parts.values():
                 part.set_speed_limits(1)
             time.sleep(0.05)
@@ -534,10 +532,11 @@ class ReachySDK:
             for part in self.info._enabled_parts.values():
                 part.set_speed_limits(speed_limit_high)
             time.sleep(0.4)
-            success = self.is_on() and (
-                (not self._l_arm or not self._l_arm.gripper or self._l_arm.gripper.is_on())
-                and (not self._r_arm or not self._r_arm.gripper or self._r_arm.gripper.is_on())
-            )
+            ite += 1
+
+        if ite == max_iterations:
+            self._logger.warning("Failed to turn on Reachy,")
+            return False
 
         return True
 
@@ -631,6 +630,10 @@ class ReachySDK:
         if self._mobile_base is not None and self._mobile_base.is_on():
             return False
         return True
+
+    def _is_fully_on(self) -> bool:
+        """Check if the robot and its grippers (if they exist) are turned on."""
+        return self.is_on() and all(arm.gripper.is_on() if arm and arm.gripper else True for arm in [self._l_arm, self._r_arm])
 
     def reset_default_limits(self) -> None:
         """Set back speed and torque limits of all parts to maximum value (100)."""

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -9,11 +9,13 @@ You can also send joint commands, compute forward or inverse kinematics.
 # from reachy2_sdk_api.dynamixel_motor_pb2_grpc import DynamixelMotorServiceStub
 # from .dynamixel_motor import DynamixelMotor
 
+from __future__ import annotations
+
 import threading
 import time
 from collections import namedtuple
 from logging import getLogger
-from typing import Dict, Optional
+from typing import Any, Dict, Optional, Type
 
 import grpc
 from google.protobuf.empty_pb2 import Empty
@@ -57,6 +59,19 @@ class ReachySDK:
         and performing movements.
     """
 
+    _instances_by_host: Dict[str, "ReachySDK"] = {}
+
+    def __new__(
+        cls: Type[ReachySDK], host: str, sdk_port: int = 50051, audio_port: int = 50063, video_port: int = 50065
+    ) -> ReachySDK:
+        """Ensure only one instance per IP is created."""
+        if host in cls._instances_by_host:
+            return cls._instances_by_host[host]
+
+        instance = super().__new__(cls)
+        cls._instances_by_host[host] = instance
+        return instance
+
     def __init__(
         self,
         host: str,
@@ -72,6 +87,10 @@ class ReachySDK:
             audio_port: The gRPC port for audio services. Default is 50063.
             video_port: The gRPC port for video services. Default is 50065.
         """
+        if hasattr(self, "_initialized"):
+            self._logger.warning("An instance already exists.")
+            return
+
         self._logger = getLogger(__name__)
         self._host = host
         self._sdk_port = sdk_port
@@ -79,8 +98,8 @@ class ReachySDK:
         self._video_port = video_port
 
         self._grpc_connected = False
+        self._initialized = True
 
-        # declared to help mypy. actually filled in self._setup_parts()
         self._r_arm: Optional[Arm] = None
         self._l_arm: Optional[Arm] = None
         self._head: Optional[Head] = None
@@ -139,11 +158,15 @@ class ReachySDK:
 
         self._grpc_connected = False
         self._grpc_channel.close()
+        self._grpc_channel = None
 
         self._head = None
         self._r_arm = None
         self._l_arm = None
         self._mobile_base = None
+
+        if self._host in self._instances_by_host:
+            del self._instances_by_host[self._host]
 
         self._logger.info("Disconnected from Reachy.")
 
@@ -415,8 +438,7 @@ class ReachySDK:
 
     def _start_sync_in_bg(self) -> None:
         """Start background synchronization with the robot."""
-        channel = grpc.insecure_channel(f"{self._host}:{self._sdk_port}")
-        reachy_stub = reachy_pb2_grpc.ReachyServiceStub(channel)
+        reachy_stub = reachy_pb2_grpc.ReachyServiceStub(self._grpc_channel)
         self._get_stream_update_loop(reachy_stub, freq=100)
 
     def _get_stream_update_loop(self, reachy_stub: reachy_pb2_grpc.ReachyServiceStub, freq: float) -> None:
@@ -430,21 +452,28 @@ class ReachySDK:
         try:
             for state_update in reachy_stub.StreamReachyState(stream_req):
                 self._update_timestamp = state_update.timestamp
-                if self._l_arm is not None:
-                    self._l_arm._update_with(state_update.l_arm_state)
-                    if self._l_arm.gripper is not None:
-                        self._l_arm.gripper._update_with(state_update.l_hand_state)
-                if self._r_arm is not None:
-                    self._r_arm._update_with(state_update.r_arm_state)
-                    if self._r_arm.gripper is not None:
-                        self._r_arm.gripper._update_with(state_update.r_hand_state)
-                if self._head is not None:
-                    self._head._update_with(state_update.head_state)
-                if self._mobile_base is not None:
-                    self._mobile_base._update_with(state_update.mobile_base_state)
-        except grpc._channel._MultiThreadedRendezvous:
-            self._grpc_connected = False
-            raise ConnectionError(f"Connection with Reachy ip:{self._host} lost, check the sdk server status.")
+
+                self._update_part(self._l_arm, state_update.l_arm_state)
+                self._update_part(self._r_arm, state_update.r_arm_state)
+                self._update_part(self._head, state_update.head_state)
+                self._update_part(self._mobile_base, state_update.mobile_base_state)
+
+                if self._l_arm and self._l_arm.gripper:
+                    self._l_arm.gripper._update_with(state_update.l_hand_state)
+                if self._r_arm and self._r_arm.gripper:
+                    self._r_arm.gripper._update_with(state_update.r_hand_state)
+
+        except grpc.RpcError as e:
+            if e.code() == grpc.StatusCode.CANCELLED:
+                self._logger.warning("Reachy gRPC stream is shutting down.")
+            else:
+                self._grpc_connected = False
+                raise ConnectionError(f"Connection with Reachy ip:{self._host} lost, check the SDK server status.")
+
+    def _update_part(self, part: Optional[Any], state: Any) -> None:
+        """Helper function to update a robot part if it exists."""
+        if part is not None:
+            part._update_with(state)
 
     def _audit(self) -> None:
         """Periodically perform an audit of the robot's components."""
@@ -476,27 +505,37 @@ class ReachySDK:
         return audit_dict
 
     def turn_on(self) -> bool:
-        """Activate all motors of the robot's parts.
+        """Activate all motors of the robot's parts if all of them are not already turned on.
 
         Returns:
             `True` if successful, `False` otherwise.
         """
-        speed_limit_high = 25
-
         if not self._grpc_connected or not self.info:
             self._logger.warning("Cannot turn on Reachy, not connected.")
             return False
-        for part in self.info._enabled_parts.values():
-            part.set_speed_limits(1)
-        time.sleep(0.05)
-        for part in self.info._enabled_parts.values():
-            part._turn_on()
-        if self._mobile_base is not None:
-            self._mobile_base._turn_on()
-        time.sleep(0.05)
-        for part in self.info._enabled_parts.values():
-            part.set_speed_limits(speed_limit_high)
-        time.sleep(0.4)
+
+        speed_limit_high = 25
+        success = self.is_on() and (
+            (not self._l_arm or not self._l_arm.gripper or self._l_arm.gripper.is_on())
+            and (not self._r_arm or not self._r_arm.gripper or self._r_arm.gripper.is_on())
+        )
+
+        while not success:
+            for part in self.info._enabled_parts.values():
+                part.set_speed_limits(1)
+            time.sleep(0.05)
+            for part in self.info._enabled_parts.values():
+                part._turn_on()
+            if self._mobile_base is not None:
+                self._mobile_base._turn_on()
+            time.sleep(0.05)
+            for part in self.info._enabled_parts.values():
+                part.set_speed_limits(speed_limit_high)
+            time.sleep(0.4)
+            success = self.is_on() and (
+                (not self._l_arm or not self._l_arm.gripper or self._l_arm.gripper.is_on())
+                and (not self._r_arm or not self._r_arm.gripper or self._r_arm.gripper.is_on())
+            )
 
         return True
 

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -61,9 +61,7 @@ class ReachySDK:
 
     _instances_by_host: Dict[str, "ReachySDK"] = {}
 
-    def __new__(
-        cls: Type[ReachySDK], host: str, sdk_port: int = 50051, audio_port: int = 50063, video_port: int = 50065
-    ) -> ReachySDK:
+    def __new__(cls: Type[ReachySDK], host: str) -> ReachySDK:
         """Ensure only one connected instance per IP is created."""
         if host in cls._instances_by_host:
             if cls._instances_by_host[host]._grpc_connected:

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -87,11 +87,13 @@ class ReachySDK:
             audio_port: The gRPC port for audio services. Default is 50063.
             video_port: The gRPC port for video services. Default is 50065.
         """
+
+        self._logger = getLogger(__name__)
+
         if hasattr(self, "_initialized"):
             self._logger.warning("An instance already exists.")
             return
 
-        self._logger = getLogger(__name__)
         self._host = host
         self._sdk_port = sdk_port
         self._audio_port = audio_port

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -64,9 +64,12 @@ class ReachySDK:
     def __new__(
         cls: Type[ReachySDK], host: str, sdk_port: int = 50051, audio_port: int = 50063, video_port: int = 50065
     ) -> ReachySDK:
-        """Ensure only one instance per IP is created."""
+        """Ensure only one connected instance per IP is created."""
         if host in cls._instances_by_host:
-            return cls._instances_by_host[host]
+            if cls._instances_by_host[host]._grpc_connected:
+                return cls._instances_by_host[host]
+            else:
+                del cls._instances_by_host[host]
 
         instance = super().__new__(cls)
         cls._instances_by_host[host] = instance
@@ -87,7 +90,6 @@ class ReachySDK:
             audio_port: The gRPC port for audio services. Default is 50063.
             video_port: The gRPC port for video services. Default is 50065.
         """
-
         self._logger = getLogger(__name__)
 
         if hasattr(self, "_initialized"):
@@ -154,6 +156,9 @@ class ReachySDK:
         Args:
             lost_connection: If `True`, indicates that the connection was lost unexpectedly.
         """
+        if self._host in self._instances_by_host:
+            del self._instances_by_host[self._host]
+
         if not self._grpc_connected:
             self._logger.warning("Already disconnected from Reachy.")
             return
@@ -166,9 +171,6 @@ class ReachySDK:
         self._r_arm = None
         self._l_arm = None
         self._mobile_base = None
-
-        if self._host in self._instances_by_host:
-            del self._instances_by_host[self._host]
 
         self._logger.info("Disconnected from Reachy.")
 

--- a/tests/units/online/conftest.py
+++ b/tests/units/online/conftest.py
@@ -5,6 +5,7 @@ Common functions shared by all tests
 import time
 
 import pytest
+import pytest_timeout
 
 from reachy2_sdk.reachy_sdk import ReachySDK
 

--- a/tests/units/online/conftest.py
+++ b/tests/units/online/conftest.py
@@ -5,7 +5,6 @@ Common functions shared by all tests
 import time
 
 import pytest
-import pytest_timeout
 
 from reachy2_sdk.reachy_sdk import ReachySDK
 

--- a/tests/units/online/test_multiple_connections.py
+++ b/tests/units/online/test_multiple_connections.py
@@ -59,4 +59,5 @@ def test_same_robot(reachy_sdk_zeroed: ReachySDK) -> None:
 @pytest.mark.timeout(2)
 def test_multiple_turn_on(reachy_sdk_zeroed: ReachySDK) -> None:
     for _ in range(15):
-        reachy_sdk_zeroed.turn_on()
+        reachy2 = ReachySDK("localhost")
+        reachy2.turn_on()

--- a/tests/units/online/test_multiple_connections.py
+++ b/tests/units/online/test_multiple_connections.py
@@ -56,8 +56,8 @@ def test_same_robot(reachy_sdk_zeroed: ReachySDK) -> None:
     assert np.allclose(reachy2.l_arm.get_current_positions(), move1_goal, atol=1e-03)
 
 
-@pytest.mark.timeout(2)
+@pytest.mark.online
 def test_multiple_turn_on(reachy_sdk_zeroed: ReachySDK) -> None:
     for _ in range(15):
         reachy2 = ReachySDK("localhost")
-        reachy2.turn_on()
+        assert reachy2.turn_on() == True

--- a/tests/units/online/test_multiple_connections.py
+++ b/tests/units/online/test_multiple_connections.py
@@ -54,3 +54,9 @@ def test_same_robot(reachy_sdk_zeroed: ReachySDK) -> None:
         assert np.allclose(reachy_sdk_zeroed.l_arm.get_current_positions(), reachy2.l_arm.get_current_positions(), atol=1)
     assert np.allclose(reachy_sdk_zeroed.l_arm.get_current_positions(), move1_goal, atol=1e-03)
     assert np.allclose(reachy2.l_arm.get_current_positions(), move1_goal, atol=1e-03)
+
+
+@pytest.mark.timeout(2)
+def test_multiple_turn_on(reachy_sdk_zeroed: ReachySDK) -> None:
+    for _ in range(15):
+        reachy_sdk_zeroed.turn_on()


### PR DESCRIPTION
On the actual SDK, every time after 10 connections to the SDK (without disconnection) then turn_on(), the stub is not working anymore : the turn_on stays stuck in self._stub.SetSpeedLimit(req) and if we add a timeout, it stays stuck in self._stub.TurnOn, etc. and we have to restart the kernel. 

They seem to be duplicate channel grpc errors. To avoid this, several modifications : 
- delete duplicate grpc channel  between __start_sync_in_bg()_ and _connect()_
- explicit deletion of the grpc channel in _disconnect()_
- Check that the instantiation to the host doesn't already exist to avoid redoing it. 
- Check that the robot isn't completely stiff before doing a _turn_on()_


