### PR TITLE
create max_xy_goto setter method

### DIFF
--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -175,7 +175,7 @@ class MobileBase(Part):
         """Set the maximum distance of goto method.
 
         Args:
-            distance: The desired maximum absolute distance from origin for the goto method.  
+            distance: The desired maximum absolute distance from origin for the goto method.
         """
         self._max_xy_goto
 

--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -171,6 +171,14 @@ class MobileBase(Part):
         else:
             raise ValueError(f"Drive mode requested should be in {possible_drive_modes}!")
 
+    def _set_max_xy_goto(self, distance: float) -> None:
+        """Set the maximum distance of goto method.
+
+        Args:
+            distance: The desired maximum absolute distance from origin for the goto method.  
+        """
+        self._max_xy_goto
+
     def _set_control_mode(self, mode: str) -> None:
         """Set the base's control mode.
 


### PR DESCRIPTION
This PR makes it possible to modify the existing self._max_xy_goto variable that defines how far the mobile base can go.