### PR TITLE
enhancement #450: allow opencv up to v5.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     protobuf>=4.25.0,<=4.25.3
     grpcio>=1.59.0, <=1.62.2
     pyquaternion==0.9.9
-    opencv-python>=4.8.0, < 5.0.0.0
+    opencv-python>=4.8.0, < 5.0.0
     reachy2-sdk-api>=1.0.16,  <1.1.0
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ install_requires =
     protobuf>=4.25.0,<=4.25.3
     grpcio>=1.59.0, <=1.62.2
     pyquaternion==0.9.9
-    opencv-python>=4.8.0, <4.9.0
+    opencv-python>=4.8.0, < 5.0.0.0
     reachy2-sdk-api>=1.0.16,  <1.1.0
 
 [options.packages.find]

--- a/src/examples/cameras.py
+++ b/src/examples/cameras.py
@@ -4,6 +4,7 @@ import argparse
 import logging
 
 import cv2
+import numpy as np
 
 from reachy2_sdk import ReachySDK
 from reachy2_sdk.media.camera import CameraView
@@ -59,7 +60,8 @@ def display_depth_cam() -> None:
         while True:
             rgb, ts = reachy.cameras.depth.get_frame()
             depth, ts_r = reachy.cameras.depth.get_depth_frame()
-            depth_map_normalized = cv2.normalize(depth, None, 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)  # type: ignore [attr-defined]
+            depth_map_normalized = np.empty_like(depth)
+            cv2.normalize(depth, depth_map_normalized, 0, 255, cv2.NORM_MINMAX, cv2.CV_8U)
             cv2.imshow("frame", rgb)
             cv2.imshow("depthn", depth_map_normalized)
             cv2.waitKey(1)

--- a/src/reachy2_sdk/media/camera.py
+++ b/src/reachy2_sdk/media/camera.py
@@ -78,7 +78,7 @@ class Camera:
             self._logger.warning("No frame retrieved")
             return None
         np_data = np.frombuffer(frame.data, np.uint8)
-        img = cv2.imdecode(np_data, cv2.IMREAD_COLOR)
+        img = cv2.imdecode(np_data, cv2.IMREAD_COLOR).astype(np.uint8)
         return img, frame.timestamp.ToNanoseconds()
 
     def get_compressed_frame(self, view: CameraView = CameraView.LEFT) -> Optional[Tuple[bytes, int]]:

--- a/src/reachy2_sdk/sensors/lidar.py
+++ b/src/reachy2_sdk/sensors/lidar.py
@@ -53,7 +53,7 @@ class Lidar:
             return None
         np_data = np.frombuffer(compressed_map.data, np.uint8)
         img = cv2.imdecode(np_data, cv2.IMREAD_COLOR)
-        return img  # type: ignore[no-any-return]
+        return img.astype(np.uint8)
 
     @property
     def safety_slowdown_distance(self) -> float:


### PR DESCRIPTION
follow up of this issue https://github.com/pollen-robotics/pollen-vision/issues/159
We use much of opencv with the SDK so it's safe to use any version.  The low version is limited to 4.8 to avoid any wrong installation that could mess up with pollen vision.