### PR TITLE
488 add tripod management

### DIFF
--- a/src/reachy2_sdk/parts/tripod.py
+++ b/src/reachy2_sdk/parts/tripod.py
@@ -49,7 +49,7 @@ class Tripod:
         """Clean representation of the Tripod."""
         repr_template = "<Tripod height={height} >"
         return repr_template.format(
-            height=round(self.height, 2),
+            height=round(self.height, 3),
         )
 
     @property

--- a/src/reachy2_sdk/parts/tripod.py
+++ b/src/reachy2_sdk/parts/tripod.py
@@ -55,7 +55,7 @@ class Tripod:
     @property
     def height(self) -> float:
         """Get the current height of the robot torso in meters."""
-        return self._present_position
+        return float(np.round(self._present_position, 3))
 
     def set_height(self, height: float) -> None:
         """Set the height of the tripod.

--- a/src/reachy2_sdk/parts/tripod.py
+++ b/src/reachy2_sdk/parts/tripod.py
@@ -1,0 +1,100 @@
+"""Reachy DynamixelMotor module.
+
+Handles all specific methods to DynamixelMotor.
+"""
+
+import logging
+from typing import Tuple
+
+import grpc
+import numpy as np
+from google.protobuf.wrappers_pb2 import FloatValue
+from reachy2_sdk_api.part_pb2 import PartId
+from reachy2_sdk_api.tripod_pb2 import Tripod as Tripod_proto
+from reachy2_sdk_api.tripod_pb2 import TripodCommand, TripodState
+from reachy2_sdk_api.tripod_pb2_grpc import TripodServiceStub
+
+
+class Tripod:
+    """The DynamixelMotor class represents any Dynamixel motor.
+
+    The DynamixelMotor class is used to store the up-to-date state of the motor, especially:
+    - its present_position (RO)
+    - its goal_position (RW)
+    """
+
+    def __init__(
+        self,
+        proto_msg: Tripod_proto,
+        initial_state: TripodState,
+        grpc_channel: grpc.Channel,
+    ):
+        """Initialize the DynamixelMotor with its initial state and configuration.
+
+        This sets up the motor by assigning its state based on the provided initial values.
+
+        Args:
+            proto_msg: The protobuf message containing configuration details for the part.
+            initial_state: The initial state of the tripod's joints.
+            grpc_channel: The gRPC channel used to communicate with the DynamixelMotor service.
+        """
+        self._grpc_channel = grpc_channel
+        self._stub = TripodServiceStub(grpc_channel)
+        self._part_id = PartId(id=proto_msg.part_id.id, name=proto_msg.part_id.name)
+        self._logger = logging.getLogger(__name__)
+
+        self._present_position: float
+        self._goal_position: float
+        self._update_with(initial_state)
+
+    def __repr__(self) -> str:
+        """Clean representation of the DynamixelMotor."""
+        repr_template = "< Tripod height={height} >"
+        return repr_template.format(
+            height=round(self.height, 2),
+        )
+
+    @property
+    def height(self) -> float:
+        """Get the present position of the joint in degrees."""
+        return self._present_position
+
+    def set_height(self, height: float) -> None:
+        """Set the height of the tripod.
+
+        Args:
+            height: The height of the tripod in meters.
+        """
+        limit_min, limit_max = self.get_limits()
+        if not limit_min <= height <= limit_max:
+            self._logger.warning(f"Height value {height} is out of bounds. ")
+            height = np.clip(height, limit_min, limit_max)
+            self._logger.warning(f"Setting height to the closest {height}.")
+        command = TripodCommand(
+            part_id=self._part_id,
+            height_position=FloatValue(value=height),
+        )
+        self._stub.SendCommand(command)
+
+    def reset_height(self) -> None:
+        """Reset the height of the tripod to its default position."""
+        self._stub.ResetDefaultValues(self._part_id)
+
+    def get_limits(self) -> Tuple[float, float]:
+        """Get the limits of the tripod's height.
+
+        Returns:
+            A tuple containing the minimum and maximum height values.
+        """
+        response = self._stub.GetJointsLimits(self._part_id)
+        return np.round(response.height_limit.min.value, 3), np.round(response.height_limit.max.value, 3)
+
+    def _update_with(self, new_state: TripodState) -> None:
+        """Update the present and goal positions of the joint with new state values.
+
+        Args:
+            new_state: A dictionary containing the new state values for the joint. The keys should include
+                "present_position" and "goal_position", with corresponding FloatValue objects as values.
+        """
+        self._present_position = new_state.height.present_position.value
+        self._goal_position = new_state.height.goal_position.value

--- a/src/reachy2_sdk/parts/tripod.py
+++ b/src/reachy2_sdk/parts/tripod.py
@@ -1,6 +1,6 @@
-"""Reachy DynamixelMotor module.
+"""Reachy Tripod module.
 
-Handles all specific methods to DynamixelMotor.
+Handles all specific methods to the tripod.
 """
 
 import logging
@@ -16,11 +16,9 @@ from reachy2_sdk_api.tripod_pb2_grpc import TripodServiceStub
 
 
 class Tripod:
-    """The DynamixelMotor class represents any Dynamixel motor.
+    """The Tripod class represents the fixed tripod of the robot.
 
-    The DynamixelMotor class is used to store the up-to-date state of the motor, especially:
-    - its present_position (RO)
-    - its goal_position (RW)
+    The Tripod class is used to update manually the robot tripod's height value.
     """
 
     def __init__(
@@ -29,9 +27,9 @@ class Tripod:
         initial_state: TripodState,
         grpc_channel: grpc.Channel,
     ):
-        """Initialize the DynamixelMotor with its initial state and configuration.
+        """Initialize the Tripod with its initial state and configuration.
 
-        This sets up the motor by assigning its state based on the provided initial values.
+        This sets up the tripod by assigning its state based on the provided initial values.
 
         Args:
             proto_msg: The protobuf message containing configuration details for the part.
@@ -48,7 +46,7 @@ class Tripod:
         self._update_with(initial_state)
 
     def __repr__(self) -> str:
-        """Clean representation of the DynamixelMotor."""
+        """Clean representation of the Tripod."""
         repr_template = "< Tripod height={height} >"
         return repr_template.format(
             height=round(self.height, 2),
@@ -56,7 +54,7 @@ class Tripod:
 
     @property
     def height(self) -> float:
-        """Get the present position of the joint in degrees."""
+        """Get the current height of the robot torso in meters."""
         return self._present_position
 
     def set_height(self, height: float) -> None:

--- a/src/reachy2_sdk/parts/tripod.py
+++ b/src/reachy2_sdk/parts/tripod.py
@@ -47,7 +47,7 @@ class Tripod:
 
     def __repr__(self) -> str:
         """Clean representation of the Tripod."""
-        repr_template = "< Tripod height={height} >"
+        repr_template = "<Tripod height={height} >"
         return repr_template.format(
             height=round(self.height, 2),
         )
@@ -67,7 +67,7 @@ class Tripod:
         if not limit_min <= height <= limit_max:
             self._logger.warning(f"Height value {height} is out of bounds. ")
             height = np.clip(height, limit_min, limit_max)
-            self._logger.warning(f"Setting height to the closest {height}.")
+            self._logger.warning(f"Setting height to {height}.")
         command = TripodCommand(
             part_id=self._part_id,
             height_position=FloatValue(value=height),

--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -37,6 +37,7 @@ from .parts.arm import Arm
 from .parts.head import Head
 from .parts.joints_based_part import JointsBasedPart
 from .parts.mobile_base import MobileBase
+from .parts.tripod import Tripod
 from .utils.custom_dict import CustomDict
 from .utils.utils import (
     JointsRequest,
@@ -112,6 +113,7 @@ class ReachySDK:
         self._cameras: Optional[CameraManager] = None
         self._mobile_base: Optional[MobileBase] = None
         self._info: Optional[ReachyInfo] = None
+        self._tripod: Optional[Tripod] = None
 
         self._update_timestamp: Timestamp = Timestamp(seconds=0)
 
@@ -246,6 +248,17 @@ class ReachySDK:
             self._logger.error("mobile_base does not exist with this configuration")
             return None
         return self._mobile_base
+
+    @property
+    def tripod(self) -> Optional[Tripod]:
+        """Get Reachy's fixed tripod."""
+        if not self._grpc_connected:
+            self._logger.error("Cannot get tripod, not connected to Reachy")
+            return None
+        if self._tripod is None:
+            self._logger.error("tripod does not exist with this configuration")
+            return None
+        return self._tripod
 
     @property
     def joints(self) -> CustomDict[str, OrbitaJoint]:
@@ -413,6 +426,16 @@ class ReachySDK:
             else:
                 self.info._disabled_parts.append("head")
 
+    def _setup_part_tripod(self, initial_state: ReachyState) -> None:
+        """Set up the robot's tripod based on the initial state."""
+        if not self.info:
+            self._logger.warning("Reachy is not connected")
+            return None
+
+        if self._robot.HasField("tripod"):
+            tripod = Tripod(self._robot.tripod, initial_state.tripod_state, self._grpc_channel)
+            self._tripod = tripod
+
     def _setup_parts(self) -> None:
         """Initialize all parts of the robot.
 
@@ -426,6 +449,7 @@ class ReachySDK:
         self._setup_part_l_arm(initial_state)
         self._setup_part_head(initial_state)
         self._setup_part_mobile_base(initial_state)
+        self._setup_part_tripod(initial_state)
 
     def get_update_timestamp(self) -> int:
         """Returns the timestamp (ns) of the last update.
@@ -458,6 +482,7 @@ class ReachySDK:
                 self._update_part(self._r_arm, state_update.r_arm_state)
                 self._update_part(self._head, state_update.head_state)
                 self._update_part(self._mobile_base, state_update.mobile_base_state)
+                self._update_part(self._tripod, state_update.tripod_state)
 
                 if self._l_arm and self._l_arm.gripper:
                     self._l_arm.gripper._update_with(state_update.l_hand_state)

--- a/tests/units/offline/test_tripod.py
+++ b/tests/units/offline/test_tripod.py
@@ -1,0 +1,54 @@
+import grpc
+import pytest
+from google.protobuf.wrappers_pb2 import FloatValue
+from reachy2_sdk_api.part_pb2 import PartId
+from reachy2_sdk_api.tripod_pb2 import Tripod as Tripod_proto
+from reachy2_sdk_api.tripod_pb2 import (
+    TripodAxis,
+    TripodDescription,
+    TripodJoint,
+    TripodJointState,
+    TripodState,
+)
+
+from reachy2_sdk.parts.tripod import Tripod
+
+
+@pytest.mark.offline
+def test_class() -> None:
+    grpc_channel = grpc.insecure_channel("dummy:5050")
+
+    tripod_id = PartId(name="tripod", id=100)
+
+    tripod_proto = Tripod_proto(
+        part_id=tripod_id,
+        description=TripodDescription(height_joint=TripodJoint(axis=TripodAxis.HEIGHT)),
+    )
+
+    tripod_state = TripodState(
+        part_id=tripod_id,
+        height=TripodJointState(
+            joint=TripodJoint(axis=TripodAxis.HEIGHT),
+            present_position=FloatValue(value=1.0),
+            goal_position=FloatValue(value=2.0),
+        ),
+    )
+
+    tripod = Tripod(proto_msg=tripod_proto, initial_state=tripod_state, grpc_channel=grpc_channel)
+
+    assert str(tripod) == "<Tripod height=1.0 >"
+    assert tripod.height == 1.0
+
+    new_tripod_state = TripodState(
+        part_id=tripod_id,
+        height=TripodJointState(
+            joint=TripodJoint(axis=TripodAxis.HEIGHT),
+            present_position=FloatValue(value=3.0),
+            goal_position=FloatValue(value=1.0),
+        ),
+    )
+
+    tripod._update_with(new_tripod_state)
+
+    assert tripod.height == 3.0
+    assert str(tripod) == "<Tripod height=3.0 >"

--- a/tests/units/online/test_tripod.py
+++ b/tests/units/online/test_tripod.py
@@ -1,0 +1,44 @@
+import time
+
+import pytest
+from google.protobuf.wrappers_pb2 import FloatValue
+from reachy2_sdk_api.part_pb2 import PartId
+from reachy2_sdk_api.tripod_pb2 import Tripod as Tripod_proto
+from reachy2_sdk_api.tripod_pb2 import (
+    TripodAxis,
+    TripodDescription,
+    TripodJoint,
+    TripodJointState,
+    TripodState,
+)
+
+from reachy2_sdk.parts.tripod import Tripod
+from reachy2_sdk.reachy_sdk import ReachySDK
+
+
+@pytest.mark.online
+def test_tripod(reachy_sdk_zeroed: ReachySDK) -> None:
+    assert reachy_sdk_zeroed.tripod is not None
+
+    reachy_sdk_zeroed.tripod.set_height(1.1)
+    time.sleep(0.2)
+    assert reachy_sdk_zeroed.tripod.height == 1.1
+
+    reachy_sdk_zeroed.tripod.set_height(1.16)
+    time.sleep(0.2)
+    assert reachy_sdk_zeroed.tripod.height == 1.16
+
+    height_min, height_max = reachy_sdk_zeroed.tripod.get_limits()
+    assert height_min < height_max
+
+    reachy_sdk_zeroed.tripod.set_height(height_min - 0.1)
+    time.sleep(0.2)
+    assert reachy_sdk_zeroed.tripod.height == height_min
+
+    reachy_sdk_zeroed.tripod.set_height(height_max + 0.1)
+    time.sleep(0.2)
+    assert reachy_sdk_zeroed.tripod.height == height_max
+
+    reachy_sdk_zeroed.tripod.reset_height()
+    time.sleep(0.2)
+    assert reachy_sdk_zeroed.tripod.height == height_min

--- a/tests/units/online/test_tripod.py
+++ b/tests/units/online/test_tripod.py
@@ -1,18 +1,7 @@
 import time
 
 import pytest
-from google.protobuf.wrappers_pb2 import FloatValue
-from reachy2_sdk_api.part_pb2 import PartId
-from reachy2_sdk_api.tripod_pb2 import Tripod as Tripod_proto
-from reachy2_sdk_api.tripod_pb2 import (
-    TripodAxis,
-    TripodDescription,
-    TripodJoint,
-    TripodJointState,
-    TripodState,
-)
 
-from reachy2_sdk.parts.tripod import Tripod
 from reachy2_sdk.reachy_sdk import ReachySDK
 
 


### PR DESCRIPTION
We can read tripod's height value, tripod limits and set a new height within the limits with:
- `reachy.tripod.height`
- `reachy.tripod.get_limits()`
- `reachy.tripod.set_height(1.1)`

To be used with sources from https://github.com/pollen-robotics/docker_reachy2_core/tree/166-add-tripod-management