### PR TITLE
Replay with check_positions=True takes less time

### DIFF
--- a/src/reachy2_sdk/components/antenna.py
+++ b/src/reachy2_sdk/components/antenna.py
@@ -266,7 +266,7 @@ class Antenna(IGoToBasedComponent):
         self._cancel_check = False
         t1 = time.time()
         while time.time() - t1 < 1:
-            time.sleep(0.05)
+            time.sleep(0.0001)
             if self._cancel_check:
                 # in case of multiple send_goal_positions we'll check the next call
                 return

--- a/src/reachy2_sdk/orbita/orbita.py
+++ b/src/reachy2_sdk/orbita/orbita.py
@@ -280,7 +280,7 @@ class Orbita(ABC):
         self._cancel_check = False
         t1 = time.time()
         while time.time() - t1 < 1:
-            time.sleep(0.05)
+            time.sleep(0.0001)
             if self._cancel_check:
                 # in case of multiple send_goal_positions we'll check the next call
                 return

--- a/src/reachy2_sdk/parts/hand.py
+++ b/src/reachy2_sdk/parts/hand.py
@@ -180,7 +180,7 @@ class Hand(Part, IGoToBasedPart):
         self._cancel_check = False
         t1 = time.time()
         while time.time() - t1 < 1:
-            time.sleep(0.05)
+            time.sleep(0.0001)
             if self._cancel_check:
                 # in case of multiple send_goal_positions we'll check the next call
                 return


### PR DESCRIPTION
For a recorded movement of 10sec on all joints, the replay using `reachy.send_goal_positions(check_positions=True)` takes more than 350sec.....
This change would make it take around 14sec instead