### PR TITLE
Add default fake parameter in connect function.

### DIFF
--- a/src/reachy2_sdk/reachy_sdk.py
+++ b/src/reachy2_sdk/reachy_sdk.py
@@ -131,7 +131,7 @@ class ReachySDK:
 
         self.connect(fake_only)
 
-    def connect(self, fake_only: bool) -> None:
+    def connect(self, fake_only: bool = False) -> None:
         """Connects the SDK to the robot.
 
         Args:


### PR DESCRIPTION
Raised error in Perception module of Pollen_vision because it missed the default value of fake_only parameter. 