### PR TITLE
537 reduce speed instead of raising error

### DIFF
--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -483,12 +483,12 @@ class MobileBase(Part, IGoToBasedPart):
             return
         for vel, value in {"x_vel": self._x_vel_goal, "y_vel": self._y_vel_goal}.items():
             if abs(value) > self._max_xy_vel:
-                raise ValueError(f"The absolute value of {vel} should not be more than {self._max_xy_vel}, got {abs(value)}")
+                self._x_vel_goal = self._max_xy_vel * np.sign(value)
+                self._logger.warning(f"{vel} value {value} m/s exceeds the allowed limit. Setting {vel} to the maximum of {self._max_xy_vel} m/s.")
 
         if abs(self._rot_vel_goal) > self._max_rot_vel:
-            raise ValueError(
-                f"The absolute value of rot_vel should not be more than {self._max_rot_vel}, got {abs(self._rot_vel_goal)}"
-            )
+            self._rot_vel_goal = self._max_rot_vel * np.sign(self._rot_vel_goal)
+            self._logger.warning(f"rot_vel value {value} m/s exceeds the allowed limit. Setting rot_vel to the maximum of {self._max_rot_vel} m/s.")
 
         if self._drive_mode != "cmd_vel":
             self._set_drive_mode("cmd_vel")

--- a/src/reachy2_sdk/parts/mobile_base.py
+++ b/src/reachy2_sdk/parts/mobile_base.py
@@ -484,11 +484,15 @@ class MobileBase(Part, IGoToBasedPart):
         for vel, value in {"x_vel": self._x_vel_goal, "y_vel": self._y_vel_goal}.items():
             if abs(value) > self._max_xy_vel:
                 self._x_vel_goal = self._max_xy_vel * np.sign(value)
-                self._logger.warning(f"{vel} value {value} m/s exceeds the allowed limit. Setting {vel} to the maximum of {self._max_xy_vel} m/s.")
+                self._logger.warning(
+                    f"{vel} value {value} m/s exceeds the allowed limit. Setting maximum of {self._max_xy_vel} m/s."
+                )
 
         if abs(self._rot_vel_goal) > self._max_rot_vel:
             self._rot_vel_goal = self._max_rot_vel * np.sign(self._rot_vel_goal)
-            self._logger.warning(f"rot_vel value {value} m/s exceeds the allowed limit. Setting rot_vel to the maximum of {self._max_rot_vel} m/s.")
+            self._logger.warning(
+                f"rot_vel value {value} m/s exceeds the allowed limit. Setting maximum of {self._max_rot_vel} m/s."
+            )
 
         if self._drive_mode != "cmd_vel":
             self._set_drive_mode("cmd_vel")

--- a/tests/units/offline/test_mobile_base.py
+++ b/tests/units/offline/test_mobile_base.py
@@ -73,14 +73,6 @@ def test_class() -> None:
 
     assert mobile_base.__repr__() != ""
 
-    mobile_base.set_goal_speed(vx=0.5, vy=0.5, vtheta=200)
-    with pytest.raises(ValueError):
-        mobile_base.send_speed_command()
-
-    mobile_base.set_goal_speed(vx=1.5, vy=1.5, vtheta=100)
-    with pytest.raises(ValueError):
-        mobile_base.send_speed_command()
-
     new_battery = BatteryLevel(level=FloatValue(value=20))
 
     new_drive_mode = ZuuuModeCommand(mode=ZuuuModePossiblities.FREE_WHEEL)


### PR DESCRIPTION
I suggest to set the maximum allowed speed instead of raising a value error when setting speeds, and inform the user of the change.
This is to facilitate also using speeds using trained policies on the robot, as is may predict values slighty over the maximum allowed, and this should not prevent the action from sending commands.